### PR TITLE
Fix/droidrun compat (#11)

### DIFF
--- a/installer/termux/reset.sh
+++ b/installer/termux/reset.sh
@@ -12,7 +12,8 @@ echo
 proot-distro login "${UBUNTU_DISTRO}" --shared-tmp -- \
   bash -lc '
     set -e
-    REPO_ROOT="$0"
+    REPO_ROOT="$1"
+    shift
     cd "$REPO_ROOT"
 
     if [ -f installer/ubuntu/env.sh ]; then

--- a/installer/termux/run.sh
+++ b/installer/termux/run.sh
@@ -139,6 +139,7 @@ if command -v adb >/dev/null 2>&1; then
       [ -n "\$PICK" ] || PICK="\${DEVICES[0]}"
       export DROIDRUN_SERIAL="\$PICK"
     fi
+    export ANDROID_SERIAL="\$DROIDRUN_SERIAL"
     echo "[run] adb selected serial: \${DROIDRUN_SERIAL}"
   fi
 else

--- a/installer/workspace-seed/AGENTS.mobile.md
+++ b/installer/workspace-seed/AGENTS.mobile.md
@@ -28,12 +28,10 @@ When the user asks to "open / enable / check / send / download / install / confi
 - If a tool call fails or returns `ok:false`, report failure and do NOT claim success.
 - For UI-changing tasks, verification must use one of:
   - `adb_ui_dump_xml` (preferred deterministic fallback)
-  - `android_ui_dump`
   - `android_screenshot`
 - Keep verification efficient:
   - prefer one meaningful verification after a UI-changing step
   - avoid repeated dump/find/dump sequences unless the state is ambiguous or the previous step failed
-  - prefer fused semantic actions such as `android_ui_tap_find` and `android_ui_type_find` when they fit the task
 
 ---
 

--- a/installer/workspace-seed/TOOLS.mobile.md
+++ b/installer/workspace-seed/TOOLS.mobile.md
@@ -9,7 +9,7 @@ Capability lookup lives in `skills/clawmobile-capabilities/SKILL.md`, not in a p
 
 ### Backends (3 kinds)
 - **DroidRun / Portal**: `android_agent_task` and health checks.
-- **ADB (low-level deterministic)**: `adb_*` tools and `android_*` with `backend=auto|adb`.
+- **ADB (low-level deterministic)**: `adb_*` tools and the low-level `android_*` wrappers.
 - **Termux:API (device UX)**: `tx_*` tools; completion alerts via `android_signal_complete`.
 
 > Tool selection / escalation / verification policy lives in: `skills/clawmobile-policy/SKILL.md`.

--- a/installer/workspace-seed/TOOLS.mobile.md
+++ b/installer/workspace-seed/TOOLS.mobile.md
@@ -8,7 +8,7 @@ Tool selection policy and task escalation rules live in the seeded skills.
 Capability lookup lives in `skills/clawmobile-capabilities/SKILL.md`, not in a plugin tool.
 
 ### Backends (3 kinds)
-- **DroidRun / Portal (Accessibility)**: semantic UI tools (`android_ui_*`, `android_agent_task`).
+- **DroidRun / Portal**: `android_agent_task` and health checks.
 - **ADB (low-level deterministic)**: `adb_*` tools and `android_*` with `backend=auto|adb`.
 - **Termux:API (device UX)**: `tx_*` tools; completion alerts via `android_signal_complete`.
 
@@ -31,22 +31,14 @@ Use this ownership rule when extending the system:
 #### Health / observation
 - `android_health`
 - `android_screenshot` — writes a PNG file and returns `{ ok, path, bytes, width, height }` (no base64).
-- `android_ui_dump` — may return `{ ok:false, logPath }` if Portal is unstable; deterministic fallback: `adb_ui_dump_xml`.
+- `android_ui_dump` — deterministic compatibility wrapper around `adb_ui_dump_xml`; returns XML observation with `source: "adb_ui_dump_xml"`.
 
 #### Completion alerts
 - `android_signal_complete` — attention layer; uses lightweight local completion signals.
 
 #### Agent mode
 - `android_agent_task` — preferred for multi-step UI workflows.
-  - If stuck: run `android_screenshot` or `android_ui_dump` to diagnose, then retry.
-
-#### Semantic UI tools
-- `android_ui_find`, `android_ui_tap_find`, `android_ui_type_find`
-- `android_ui_tap`, `android_ui_type`
-- Efficiency hint:
-  - Prefer `android_ui_tap_find` over `android_ui_find` + `android_ui_tap` when one matched tap is the goal.
-  - Prefer `android_ui_type_find` over `android_ui_find` + `android_ui_type` when one matched input is the goal.
-  - Use `android_ui_dump` when you need inspection or verification, not as a mandatory pre-step for every semantic action.
+  - If stuck: run `adb_ui_dump_xml` or `android_screenshot` to diagnose, then retry.
 
 #### ADB tools
 - `adb_devices`, `adb_keyevent`, `adb_ui_dump_xml`
@@ -67,7 +59,7 @@ Use this ownership rule when extending the system:
 ---
 
 ### Notes
-- If UI changes unexpectedly, re-run `android_screenshot` or `android_ui_dump` before acting.
+- If UI changes unexpectedly, re-run `adb_ui_dump_xml` or `android_screenshot` before acting.
 - If ADB shows `unauthorized`, accept the debugging prompt on the phone.
 
 <!-- CLAWMOBILE_END -->

--- a/installer/workspace-seed/skills/clawmobile-capabilities/SKILL.md
+++ b/installer/workspace-seed/skills/clawmobile-capabilities/SKILL.md
@@ -93,8 +93,7 @@ These are deterministic recovery actions to restore input method if agent mode c
 - If a **COMPLETE** entry exists for the user request: use that deterministic path and verify.
 - If only a **BOOTSTRAP** entry exists: run it once, then complete + verify using `android_agent_task`.
 - For UI-changing steps, verification must use one of:
-  - `android_ui_dump` or `android_screenshot`
-  - If Portal/UI dump is unstable: fallback to `adb_ui_dump_xml`
+  - `adb_ui_dump_xml` or `android_screenshot`
 - Never claim success unless a tool was called and the result was verified.
 
 ---

--- a/installer/workspace-seed/skills/clawmobile-capabilities/contract.json
+++ b/installer/workspace-seed/skills/clawmobile-capabilities/contract.json
@@ -162,8 +162,7 @@
     "If a **COMPLETE** entry exists for the user request: use that deterministic path and verify.",
     "If only a **BOOTSTRAP** entry exists: run it once, then complete + verify using `android_agent_task`.",
     "For UI-changing steps, verification must use one of:",
-    "  - `android_ui_dump` or `android_screenshot`",
-    "  - If Portal/UI dump is unstable: fallback to `adb_ui_dump_xml`",
+    "  - `adb_ui_dump_xml` or `android_screenshot`",
     "Never claim success unless a tool was called and the result was verified."
   ],
   "extensionNotes": [

--- a/installer/workspace-seed/skills/clawmobile-policy/SKILL.md
+++ b/installer/workspace-seed/skills/clawmobile-policy/SKILL.md
@@ -16,7 +16,7 @@ It does not add new tools; it constrains how existing tools are used.
 ## Policy: Deterministic-First (Priority)
 1. **Command-line (Termux / ADB)** when it can **COMPLETE** and/or **VERIFY** the task.
 2. **DroidRun agent mode** (`android_agent_task`) for multi-step UI workflows.
-3. **Manual UI tools** (`android_ui_*`) only when agent mode fails or is unsafe.
+3. **Manual ADB tools** (`adb_*`, `android_*`) only when agent mode fails or is unsafe.
 
 ## Decision Procedure (Strict)
 1. Consult `skills/clawmobile-capabilities/SKILL.md`.
@@ -28,15 +28,12 @@ It does not add new tools; it constrains how existing tools are used.
    - Immediately switch to `android_agent_task` to finish and verify.
 4. If no entry exists:
    - Use `android_agent_task` for UI workflows.
-   - Use manual `android_ui_*` only if agent mode fails or is unsafe.
+   - Use manual ADB tools only if agent mode fails or is unsafe.
 
 ## UI Workflow Efficiency
 - Avoid redundant UI observation on the same step.
-- Prefer fused semantic actions when they match the goal:
-  - use `android_ui_tap_find` instead of `android_ui_find` followed by `android_ui_tap`
-  - use `android_ui_type_find` instead of `android_ui_find` followed by `android_ui_type`
-- Do not run `android_ui_dump` before every semantic action by default.
-  - Use it when you need diagnosis, disambiguation, or post-action verification.
+- Do not run XML/screenshot observation before every action by default.
+  - Use `adb_ui_dump_xml` or `android_screenshot` when you need diagnosis, disambiguation, or post-action verification.
 - For a single deterministic UI action, prefer:
   1. choose the most direct tool,
   2. perform the action,
@@ -50,16 +47,15 @@ It does not add new tools; it constrains how existing tools are used.
 ## Verification Requirements (Non-negotiable)
 - Do NOT claim success unless a tool was called and the result is verified.
 - For UI-changing steps, verify using:
-  - `android_ui_dump` or `android_screenshot`
-  - If Portal is unstable: fallback to `adb_ui_dump_xml`
+  - `adb_ui_dump_xml` or `android_screenshot`
 - If a tool returns `ok:false` or fails: report failure; do not claim success.
 
 ## Escalation & Recovery
 - If deterministic path cannot verify state reliably, escalate to `android_agent_task`.
 - If `android_agent_task` appears stuck:
-  1) run `android_screenshot` or `android_ui_dump` to collect evidence,
+  1) run `android_screenshot` or `adb_ui_dump_xml` to collect evidence,
   2) retry once,
-  3) if still stuck, fall back to manual `android_ui_*` only if safe.
+  3) if still stuck, fall back to manual ADB tools only if safe.
 
 ## IME Safety
 Before pausing for user confirmation, restore the user IME if it was changed by agent mode.

--- a/openclaw-plugin-mobile-ui/pyexec/android_exec.py
+++ b/openclaw-plugin-mobile-ui/pyexec/android_exec.py
@@ -29,8 +29,12 @@ def ensure_droidrun_importable():
         return False, str(exc)
 
 
+def selected_serial() -> str:
+    return os.environ.get("DROIDRUN_SERIAL") or os.environ.get("ANDROID_SERIAL") or ""
+
+
 def _adb_base():
-    serial = os.environ.get("DROIDRUN_SERIAL") or ""
+    serial = selected_serial()
     base = ["adb"]
     if serial:
         base.extend(["-s", serial])
@@ -160,26 +164,36 @@ def cmd_health(_args):
     except Exception as exc:
         portal_err = str(exc)
 
-    return ok(
-        {
-            "python": sys.version.split()[0],
-            "cwd": os.getcwd(),
-            "droidrun_importable": ok_import,
-            "droidrun_import_error": err,
-            "droidrun_tools_importable": tools_ok,
-            "droidrun_tools_import_error": tools_err,
-            "droidrun_android_driver_importable": driver_ok,
-            "droidrun_android_driver_import_error": driver_err,
-            "portal_query_ok": portal_ok,
-            "portal_query_error": portal_err,
-            "env": {
-                "DROIDRUN_SERIAL": os.environ.get("DROIDRUN_SERIAL", ""),
-                "DROIDRUN_USE_TCP": os.environ.get("DROIDRUN_USE_TCP", ""),
-                "DROIDRUN_TCP_PORT": os.environ.get("DROIDRUN_TCP_PORT", ""),
-            },
-            "time": int(time.time()),
-        }
-    )
+    diagnostics = {
+        "python": sys.version.split()[0],
+        "cwd": os.getcwd(),
+        "droidrun_importable": ok_import,
+        "droidrun_import_error": err,
+        "droidrun_tools_importable": tools_ok,
+        "droidrun_tools_import_error": tools_err,
+        "droidrun_android_driver_importable": driver_ok,
+        "droidrun_android_driver_import_error": driver_err,
+        "portal_query_ok": portal_ok,
+        "portal_query_error": portal_err,
+        "env": {
+            "DROIDRUN_SERIAL": os.environ.get("DROIDRUN_SERIAL", ""),
+            "ANDROID_SERIAL": os.environ.get("ANDROID_SERIAL", ""),
+            "selected_serial": selected_serial(),
+            "DROIDRUN_USE_TCP": os.environ.get("DROIDRUN_USE_TCP", ""),
+            "DROIDRUN_TCP_PORT": os.environ.get("DROIDRUN_TCP_PORT", ""),
+        },
+        "time": int(time.time()),
+    }
+
+    if ok_import and portal_ok:
+        return ok(diagnostics)
+
+    reasons = []
+    if not ok_import:
+        reasons.append("droidrun_not_importable")
+    if not portal_ok:
+        reasons.append("portal_unreachable")
+    return fail("health_check_failed", {**diagnostics, "reasons": reasons})
 
 
 def cmd_agent_task(args):
@@ -191,7 +205,7 @@ def cmd_agent_task(args):
     if not goal:
         return fail("goal is required")
 
-    serial = os.environ.get("DROIDRUN_SERIAL") or None
+    serial = selected_serial() or None
     use_tcp = os.environ.get("DROIDRUN_USE_TCP", "0").lower() in ("1", "true", "yes")
 
     if args.device_serial:

--- a/openclaw-plugin-mobile-ui/pyexec/android_exec.py
+++ b/openclaw-plugin-mobile-ui/pyexec/android_exec.py
@@ -8,9 +8,6 @@ import sys
 import time
 
 
-# -------------------------
-# JSON helpers
-# -------------------------
 def ok(data):
     print(json.dumps({"ok": True, "data": data}, ensure_ascii=False))
     return 0
@@ -28,15 +25,27 @@ def ensure_droidrun_importable():
     try:
         import droidrun  # noqa: F401
         return True, None
-    except Exception as e:
-        return False, str(e)
+    except Exception as exc:
+        return False, str(exc)
 
 
-# -------------------------
-# ADB IME save/restore
-# -------------------------
+def _adb_base():
+    serial = os.environ.get("DROIDRUN_SERIAL") or ""
+    base = ["adb"]
+    if serial:
+        base.extend(["-s", serial])
+    return base
+
+
 def adb_shell(cmd: str) -> str:
-    out = subprocess.check_output(["adb", "shell", cmd], stderr=subprocess.STDOUT)
+    try:
+        out = subprocess.check_output(
+            _adb_base() + ["shell", cmd],
+            stderr=subprocess.STDOUT,
+            timeout=ADB_SHELL_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"adb_shell_timeout_after_{ADB_SHELL_TIMEOUT_S:.0f}s") from exc
     return out.decode("utf-8", errors="ignore").strip()
 
 
@@ -45,9 +54,8 @@ def get_default_ime() -> str:
 
 
 def set_ime(ime_id: str) -> None:
-    if not ime_id:
-        return
-    adb_shell(f"ime set {ime_id}")
+    if ime_id:
+        adb_shell(f"ime set {ime_id}")
 
 
 class ImeGuard:
@@ -70,534 +78,109 @@ class ImeGuard:
         return False
 
 
-# -------------------------
-# DroidRun tools factory
-# -------------------------
-def _tools_kwargs():
-    serial = os.environ.get("DROIDRUN_SERIAL") or None
-    use_tcp = os.environ.get("DROIDRUN_USE_TCP", "0").lower() in ("1", "true", "yes")
-    remote_tcp_port = int(os.environ.get("DROIDRUN_TCP_PORT", "8080"))
-    return dict(serial=serial, use_tcp=use_tcp, remote_tcp_port=remote_tcp_port)
+PORTAL_AUTHORITY = "content://com.droidrun.portal"
+ADB_SHELL_TIMEOUT_S = 5.0
+PORTAL_QUERY_TIMEOUT_S = 3.0
 
 
-async def _make_tools():
-    from droidrun.tools import AdbTools
-    return AdbTools(**_tools_kwargs())
+def _extract_json_block(text: str):
+    text = (text or "").strip()
+    if not text:
+        raise RuntimeError("empty portal response")
 
-
-# -------------------------
-# a11y_tree parsing helpers
-# -------------------------
-def _iter_nodes(tree):
-    """
-    Best-effort traversal:
-    - If tree is list: iterate elements; recurse into children-like fields
-    - If tree is dict: recurse into values that look like children
-    """
-    if tree is None:
-        return
-    if isinstance(tree, list):
-        for item in tree:
-            yield from _iter_nodes(item)
-    elif isinstance(tree, dict):
-        # Yield this node if it looks like a node
-        yield tree
-        # common children keys
-        for k in ("children", "child", "nodes", "elements"):
-            v = tree.get(k)
-            if isinstance(v, (list, dict)):
-                yield from _iter_nodes(v)
-
-
-def _to_int(x, default=None):
     try:
-        return int(x)
+        return json.loads(text)
     except Exception:
-        return default
+        pass
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start >= 0 and end > start:
+        return json.loads(text[start : end + 1])
+
+    raise RuntimeError(f"unable to parse portal json: {text[:300]}")
 
 
-def _extract_bounds(node):
-    # different portal versions may use different keys
-    for k in ("bounds", "rect", "bbox"):
-        v = node.get(k)
-        if isinstance(v, (list, tuple)) and len(v) == 4:
-            return [int(v[0]), int(v[1]), int(v[2]), int(v[3])]
-        if isinstance(v, dict):
-            # {left, top, right, bottom}
-            if all(t in v for t in ("left", "top", "right", "bottom")):
-                return [int(v["left"]), int(v["top"]), int(v["right"]), int(v["bottom"])]
-    return None
+def _unwrap_portal_payload(payload):
+    if isinstance(payload, dict) and payload.get("status") == "error":
+        raise RuntimeError(payload.get("error") or "portal_error")
+
+    data = payload.get("data") if isinstance(payload, dict) else payload
+    if isinstance(data, str):
+        stripped = data.strip()
+        if (stripped.startswith("{") and stripped.endswith("}")) or (
+            stripped.startswith("[") and stripped.endswith("]")
+        ):
+            try:
+                return json.loads(stripped)
+            except Exception:
+                return data
+    return data
 
 
-def _simplify_node(node):
-    # per community examples, nodes usually carry index/text/etc.  [oai_citation:3‡GitHub](https://github.com/droidrun/droidrun/issues/223?utm_source=chatgpt.com)
-    return {
-        "index": _to_int(node.get("index")),
-        "text": node.get("text") or node.get("label") or "",
-        "content_desc": node.get("contentDescription") or node.get("content_desc") or "",
-        "resource_id": node.get("resourceId") or node.get("resource_id") or node.get("viewIdResourceName") or "",
-        "class": node.get("className") or node.get("class") or node.get("type") or "",
-        "clickable": bool(node.get("clickable")) if "clickable" in node else None,
-        "enabled": bool(node.get("enabled")) if "enabled" in node else None,
-        "focused": bool(node.get("focused")) if "focused" in node else None,
-        "bounds": _extract_bounds(node),
-    }
+def portal_query(path: str):
+    try:
+        out = subprocess.check_output(
+            _adb_base() + ["shell", "content", "query", "--uri", f"{PORTAL_AUTHORITY}/{path}"],
+            stderr=subprocess.STDOUT,
+            timeout=PORTAL_QUERY_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"portal_query_timeout_after_{PORTAL_QUERY_TIMEOUT_S:.0f}s:{path}"
+        ) from exc
+    payload = _extract_json_block(out.decode("utf-8", errors="ignore"))
+    return _unwrap_portal_payload(payload)
 
-def _norm(s: str) -> str:
-    return (s or "").strip().lower()
 
-def _contains(hay: str, needle: str) -> bool:
-    hay = _norm(hay)
-    needle = _norm(needle)
-    return bool(needle) and needle in hay
-
-def _score_match(node_s, query):
-    """
-    node_s: simplified node dict
-    query: dict of filters
-    returns (matched: bool, score: int, reasons: list[str])
-    """
-    reasons = []
-    score = 0
-
-    text = node_s.get("text", "")
-    desc = node_s.get("content_desc", "")
-    rid = node_s.get("resource_id", "")
-    cls = node_s.get("class", "")
-
-    # hard filters
-    if query.get("clickableOnly") and node_s.get("clickable") is not True:
-        return False, 0, ["not_clickable"]
-    if query.get("enabledOnly") and node_s.get("enabled") is not True:
-        return False, 0, ["not_enabled"]
-
-    # soft matches add score
-    tc = query.get("textContains") or ""
-    if tc:
-        if _contains(text, tc):
-            score += 50
-            reasons.append("textContains")
-        else:
-            return False, 0, ["text_miss"]
-
-    dc = query.get("descContains") or ""
-    if dc:
-        if _contains(desc, dc):
-            score += 40
-            reasons.append("descContains")
-        else:
-            return False, 0, ["desc_miss"]
-
-    rc = query.get("resourceIdContains") or ""
-    if rc:
-        if _contains(rid, rc):
-            score += 80
-            reasons.append("resourceIdContains")
-        else:
-            return False, 0, ["resource_id_miss"]
-
-    cc = query.get("classContains") or ""
-    if cc:
-        if _contains(cls, cc):
-            score += 20
-            reasons.append("classContains")
-        else:
-            return False, 0, ["class_miss"]
-
-    # preference boosts
-    if query.get("preferClickable") and node_s.get("clickable") is True:
-        score += 10
-        reasons.append("preferClickable+")
-    if node_s.get("focused") is True:
-        score += 5
-        reasons.append("focused+")
-
-    # tiny bias for having bounds
-    if node_s.get("bounds"):
-        score += 1
-
-    return True, score, reasons
-
-# -------------------------
-# Commands
-# -------------------------
 def cmd_health(_args):
     ok_import, err = ensure_droidrun_importable()
-    return ok({
-        "python": sys.version.split()[0],
-        "cwd": os.getcwd(),
-        "droidrun_importable": ok_import,
-        "droidrun_import_error": err,
-        "env": {
-            "DROIDRUN_SERIAL": os.environ.get("DROIDRUN_SERIAL", ""),
-            "DROIDRUN_USE_TCP": os.environ.get("DROIDRUN_USE_TCP", ""),
-            "DROIDRUN_TCP_PORT": os.environ.get("DROIDRUN_TCP_PORT", ""),
-        },
-        "time": int(time.time())
-    })
-
-
-def cmd_screenshot(args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    async def _run():
-        tools = await _make_tools()
-        fmt, image_bytes = await tools.take_screenshot(hide_overlay=True)
-        out_path = (args.output or "").strip()
-        if not out_path:
-            out_path = f"/tmp/screenshot_{int(time.time())}.png"
-        os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
-        with open(out_path, "wb") as f:
-            f.write(image_bytes)
-        return {"format": fmt, "path": out_path, "bytes": len(image_bytes)}
+    tools_ok = False
+    tools_err = None
+    driver_ok = False
+    driver_err = None
 
     try:
-        data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("screenshot_failed", {"repr": repr(e)})
-
-
-def cmd_tap(args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    async def _run():
-        tools = await _make_tools()
-        success = await tools.tap_by_coordinates(args.x, args.y)
-        return {"success": bool(success), "x": args.x, "y": args.y}
+        import droidrun.tools  # noqa: F401
+        tools_ok = True
+    except Exception as exc:
+        tools_err = str(exc)
 
     try:
-        # Non-text action: avoid extra IME save/restore ADB round-trips.
-        data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("tap_failed", {"repr": repr(e)})
+        from droidrun.tools import AndroidDriver  # noqa: F401
+        driver_ok = True
+    except Exception as exc:
+        driver_err = str(exc)
 
+    portal_ok = False
+    portal_err = None
+    try:
+        portal_query("ping")
+        portal_ok = True
+    except Exception as exc:
+        portal_err = str(exc)
 
-def cmd_swipe(args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    async def _run():
-        tools = await _make_tools()
-        success = await tools.swipe(args.x1, args.y1, args.x2, args.y2, duration_ms=args.duration_ms)
-        return {
-            "success": bool(success),
-            "x1": args.x1, "y1": args.y1, "x2": args.x2, "y2": args.y2,
-            "duration_ms": args.duration_ms,
+    return ok(
+        {
+            "python": sys.version.split()[0],
+            "cwd": os.getcwd(),
+            "droidrun_importable": ok_import,
+            "droidrun_import_error": err,
+            "droidrun_tools_importable": tools_ok,
+            "droidrun_tools_import_error": tools_err,
+            "droidrun_android_driver_importable": driver_ok,
+            "droidrun_android_driver_import_error": driver_err,
+            "portal_query_ok": portal_ok,
+            "portal_query_error": portal_err,
+            "env": {
+                "DROIDRUN_SERIAL": os.environ.get("DROIDRUN_SERIAL", ""),
+                "DROIDRUN_USE_TCP": os.environ.get("DROIDRUN_USE_TCP", ""),
+                "DROIDRUN_TCP_PORT": os.environ.get("DROIDRUN_TCP_PORT", ""),
+            },
+            "time": int(time.time()),
         }
+    )
 
-    try:
-        # Non-text action: avoid extra IME save/restore ADB round-trips.
-        data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("swipe_failed", {"repr": repr(e)})
-
-
-def cmd_type(args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    async def _run():
-        tools = await _make_tools()
-        result = await tools.input_text(args.text, index=args.index, clear=args.clear)
-        return {"result": result, "index": args.index, "clear": bool(args.clear)}
-
-    try:
-        with ImeGuard():
-            data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("type_failed", {"repr": repr(e)})
-
-
-def cmd_get_state(_args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    async def _run():
-        tools = await _make_tools()
-        formatted_text, focused_text, a11y_tree, phone_state = await tools.get_state()
-        return {
-            "formatted_text": formatted_text,
-            "focused_text": focused_text,
-            "a11y_tree": a11y_tree,
-            "phone_state": phone_state,
-        }
-
-    try:
-        data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("get_state_failed", {"repr": repr(e)})
-
-
-# ---- NEW: UI a11y dump ----
-def cmd_ui_dump(args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    async def _run():
-        tools = await _make_tools()
-        formatted_text, focused_text, a11y_tree, phone_state = await tools.get_state()
-        nodes = []
-        seen = set()
-        for n in _iter_nodes(a11y_tree):
-            idx = _to_int(n.get("index"))
-            if idx is None:
-                continue
-            if args.only_clickable and not n.get("clickable"):
-                continue
-            if idx in seen:
-                continue
-            seen.add(idx)
-            nodes.append(_simplify_node(n))
-        nodes.sort(key=lambda x: (x["index"] if x["index"] is not None else 10**9))
-        return {
-            "count": len(nodes),
-            "only_clickable": bool(args.only_clickable),
-            "nodes": nodes,
-            # keep a bit of context (helpful for the model)
-            "focused_text": focused_text,
-            "phone_state": phone_state,
-        }
-
-    try:
-        # Read-only path: avoid extra IME save/restore ADB round-trips.
-        data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("ui_dump_failed", {"repr": repr(e)})
-
-def cmd_ui_find(args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    query = {
-        "textContains": args.text_contains or "",
-        "descContains": args.desc_contains or "",
-        "resourceIdContains": args.resource_id_contains or "",
-        "classContains": args.class_contains or "",
-        "clickableOnly": bool(args.clickable_only),
-        "enabledOnly": bool(args.enabled_only),
-        "preferClickable": bool(args.prefer_clickable),
-        "limit": int(args.limit),
-    }
-
-    async def _run():
-        tools = await _make_tools()
-        _formatted_text, focused_text, a11y_tree, phone_state = await tools.get_state()
-
-        nodes = []
-        seen = set()
-        for n in _iter_nodes(a11y_tree):
-            idx = _to_int(n.get("index"))
-            if idx is None or idx in seen:
-                continue
-            seen.add(idx)
-
-            sn = _simplify_node(n)
-            matched, score, reasons = _score_match(sn, query)
-            if not matched:
-                continue
-
-            sn["score"] = score
-            sn["reasons"] = reasons
-            nodes.append(sn)
-
-        nodes.sort(key=lambda x: (-int(x.get("score", 0)), x.get("index", 10**9)))
-        nodes = nodes[: query["limit"]]
-
-        return {
-            "query": query,
-            "count": len(nodes),
-            "nodes": nodes,
-            "focused_text": focused_text,
-            "phone_state": phone_state,
-        }
-
-    try:
-        # Read-only path: avoid extra IME save/restore ADB round-trips.
-        data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("ui_find_failed", {"repr": repr(e)})
-
-# ---- NEW: UI tap by index ----
-def cmd_ui_tap(args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    async def _run():
-        tools = await _make_tools()
-        # tap_by_index(index) ([docs.droidrun.ai](https://docs.droidrun.ai/sdk/adb-tools))
-        success = await tools.tap_by_index(args.index)
-        return {"success": bool(success), "index": args.index}
-
-    try:
-        # Non-text action: avoid extra IME save/restore ADB round-trips.
-        data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("ui_tap_failed", {"repr": repr(e)})
-
-
-# ---- NEW: UI type by index ----
-def cmd_ui_type(args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    async def _run():
-        tools = await _make_tools()
-        result = await tools.input_text(args.text, index=args.index, clear=args.clear)
-        return {"result": result, "index": args.index, "clear": bool(args.clear)}
-
-    try:
-        with ImeGuard():
-            data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("ui_type_failed", {"repr": repr(e)})
-
-def cmd_ui_tap_find(args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    query = {
-        "textContains": args.text_contains or "",
-        "descContains": args.desc_contains or "",
-        "resourceIdContains": args.resource_id_contains or "",
-        "classContains": args.class_contains or "",
-        "clickableOnly": bool(args.clickable_only),
-        "enabledOnly": bool(args.enabled_only),
-        "preferClickable": True,  # tap 默认偏好 clickable
-        "limit": int(args.limit),
-    }
-
-    async def _run():
-        tools = await _make_tools()
-        _formatted_text, focused_text, a11y_tree, phone_state = await tools.get_state()
-
-        nodes = []
-        seen = set()
-        for n in _iter_nodes(a11y_tree):
-            idx = _to_int(n.get("index"))
-            if idx is None or idx in seen:
-                continue
-            seen.add(idx)
-
-            sn = _simplify_node(n)
-            matched, score, reasons = _score_match(sn, query)
-            if not matched:
-                continue
-            sn["score"] = score
-            sn["reasons"] = reasons
-            nodes.append(sn)
-
-        nodes.sort(key=lambda x: (-int(x.get("score", 0)), x.get("index", 10**9)))
-        nodes = nodes[: query["limit"]]
-
-        if not nodes:
-            return {"success": False, "reason": "no_match", "query": query, "focused_text": focused_text, "phone_state": phone_state}
-
-        top = nodes[0]
-        idx = int(top["index"])
-
-        success = await tools.tap_by_index(idx)
-        return {
-            "success": bool(success),
-            "tapped_index": idx,
-            "candidate": top,
-            "alternates": nodes[1:],
-            "query": query,
-        }
-
-    try:
-        # Non-text action: avoid extra IME save/restore ADB round-trips.
-        data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("ui_tap_find_failed", {"repr": repr(e)})
-    
-def cmd_ui_type_find(args):
-    ok_import, err = ensure_droidrun_importable()
-    if not ok_import:
-        return fail("droidrun not importable", {"import_error": err})
-
-    query = {
-        "textContains": args.text_contains or "",
-        "descContains": args.desc_contains or "",
-        "resourceIdContains": args.resource_id_contains or "",
-        "classContains": args.class_contains or "",
-        "clickableOnly": False,     # 输入框不一定 clickable
-        "enabledOnly": bool(args.enabled_only),
-        "preferClickable": False,
-        "limit": int(args.limit),
-    }
-
-    async def _run():
-        tools = await _make_tools()
-        _formatted_text, focused_text, a11y_tree, phone_state = await tools.get_state()
-
-        nodes = []
-        seen = set()
-        for n in _iter_nodes(a11y_tree):
-            idx = _to_int(n.get("index"))
-            if idx is None or idx in seen:
-                continue
-            seen.add(idx)
-
-            sn = _simplify_node(n)
-            matched, score, reasons = _score_match(sn, query)
-            if not matched:
-                continue
-            sn["score"] = score
-            sn["reasons"] = reasons
-            nodes.append(sn)
-
-        nodes.sort(key=lambda x: (-int(x.get("score", 0)), x.get("index", 10**9)))
-        nodes = nodes[: query["limit"]]
-
-        if not nodes:
-            return {"success": False, "reason": "no_match", "query": query, "focused_text": focused_text, "phone_state": phone_state}
-
-        top = nodes[0]
-        idx = int(top["index"])
-
-        # 可选：先 tap 聚焦，再输入
-        await tools.tap_by_index(idx)
-        result = await tools.input_text(args.text, index=idx, clear=args.clear)
-
-        return {
-            "success": True,
-            "typed_index": idx,
-            "result": result,
-            "candidate": top,
-            "alternates": nodes[1:],
-            "query": query,
-            "text_len": len(args.text or ""),
-            "clear": bool(args.clear),
-        }
-
-    try:
-        with ImeGuard():
-            data = asyncio.run(_run())
-        return ok(data)
-    except Exception as e:
-        return fail("ui_type_find_failed", {"repr": repr(e)})
 
 def cmd_agent_task(args):
     ok_import, err = ensure_droidrun_importable()
@@ -620,178 +203,105 @@ def cmd_agent_task(args):
     timeout = int(args.timeout)
 
     async def _run():
-        from droidrun import DroidAgent, DeviceConfig
+        from droidrun import DeviceConfig, DroidAgent
         from droidrun.config_manager import DroidrunConfig
 
         device_cfg = DeviceConfig(serial=serial, use_tcp=use_tcp)
         cfg = DroidrunConfig(device=device_cfg)
 
-        # best-effort set max_steps if this version exposes agent config
         if getattr(cfg, "agent", None) is not None and hasattr(cfg.agent, "max_steps"):
             cfg.agent.max_steps = max_steps
-
-        # agent = DroidAgent(goal=goal, config=cfg, timeout=timeout)
-        # result = await agent.run()
 
         provider = os.environ.get("DROIDRUN_PROVIDER", "").strip()
         model = os.environ.get("DROIDRUN_MODEL", "").strip()
 
         llm = None
         if provider and model:
-            # v2 docs show load_llm(provider_name=..., model=...)
             load_errs = []
             try:
                 from droidrun.agent.utils.llm_picker import load_llm
+
                 llm = load_llm(provider_name=provider, model=model, temperature=0.2)
-            except Exception as e:
-                load_errs.append(f"llm_picker: {repr(e)}")
+            except Exception as exc:
+                load_errs.append(f"llm_picker: {repr(exc)}")
 
             if llm is None:
                 try:
-                    from droidrun.agent.utils.llm import load_llm  # alt path in some versions
+                    from droidrun.agent.utils.llm import load_llm
+
                     llm = load_llm(provider_name=provider, model=model, temperature=0.2)
-                except Exception as e:
-                    load_errs.append(f"llm: {repr(e)}")
+                except Exception as exc:
+                    load_errs.append(f"llm: {repr(exc)}")
 
             if llm is None:
-                return fail("llm_load_failed", {"provider": provider, "model": model, "errors": load_errs})
+                raise RuntimeError(
+                    json.dumps(
+                        {
+                            "error": "llm_load_failed",
+                            "provider": provider,
+                            "model": model,
+                            "errors": load_errs,
+                        },
+                        ensure_ascii=False,
+                    )
+                )
 
         agent = DroidAgent(goal=goal, config=cfg, llms=llm, timeout=timeout)
         result = await agent.run()
-
 
         out = {
             "success": bool(getattr(result, "success", False)),
             "reason": getattr(result, "reason", ""),
             "steps": int(getattr(result, "steps", 0) or 0),
         }
-        so = getattr(result, "structured_output", None)
-        if so is not None:
-            out["structured_output"] = so
+        structured_output = getattr(result, "structured_output", None)
+        if structured_output is not None:
+            out["structured_output"] = structured_output
         return out
 
     try:
         with ImeGuard():
             data = asyncio.run(_run())
         return ok(data)
-    except Exception as e:
-        return fail("agent_task_failed", {"repr": repr(e)})
-    
-# -------------------------
-# CLI
-# -------------------------
+    except Exception as exc:
+        message = str(exc)
+        try:
+            parsed = json.loads(message)
+        except Exception:
+            parsed = None
+
+        if isinstance(parsed, dict) and parsed.get("error"):
+            extra = {k: v for k, v in parsed.items() if k != "error"}
+            return fail(parsed["error"], extra or None)
+
+        return fail("agent_task_failed", {"repr": repr(exc)})
+
+
 def main():
-    p = argparse.ArgumentParser()
-    sub = p.add_subparsers(dest="cmd", required=True)
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("health")
 
-    ps = sub.add_parser("screenshot")
-    ps.add_argument("--output", default="")
+    agent_parser = sub.add_parser("agent_task")
+    agent_parser.add_argument("goal")
+    agent_parser.add_argument("--steps", type=int, default=30)
+    agent_parser.add_argument("--timeout", type=int, default=1000)
+    agent_parser.add_argument("--device-serial", dest="device_serial", default="")
+    agent_parser.add_argument("--tcp", action="store_true")
 
-    pt = sub.add_parser("tap")
-    pt.add_argument("x", type=int)
-    pt.add_argument("y", type=int)
-
-    pw = sub.add_parser("swipe")
-    pw.add_argument("x1", type=int)
-    pw.add_argument("y1", type=int)
-    pw.add_argument("x2", type=int)
-    pw.add_argument("y2", type=int)
-    pw.add_argument("--duration-ms", dest="duration_ms", type=int, default=300)
-
-    pty = sub.add_parser("type")
-    pty.add_argument("text")
-    pty.add_argument("--index", type=int, default=-1)
-    pty.add_argument("--clear", action="store_true")
-
-    sub.add_parser("get_state")
-
-    # NEW: ui_dump
-    pud = sub.add_parser("ui_dump")
-    pud.add_argument("--only-clickable", action="store_true")
-
-    # NEW: ui_tap
-    put = sub.add_parser("ui_tap")
-    put.add_argument("index", type=int)
-
-    # NEW: ui_type
-    pui = sub.add_parser("ui_type")
-    pui.add_argument("index", type=int)
-    pui.add_argument("text")
-    pui.add_argument("--clear", action="store_true")
-
-    # NEW: ui_find
-    puf = sub.add_parser("ui_find")
-    puf.add_argument("--text-contains", dest="text_contains", default="")
-    puf.add_argument("--desc-contains", dest="desc_contains", default="")
-    puf.add_argument("--resource-id-contains", dest="resource_id_contains", default="")
-    puf.add_argument("--class-contains", dest="class_contains", default="")
-    puf.add_argument("--clickable-only", action="store_true")
-    puf.add_argument("--enabled-only", action="store_true")
-    puf.add_argument("--prefer-clickable", action="store_true")
-    puf.add_argument("--limit", type=int, default=8)
-
-    # NEW: ui_tap_find
-    putf = sub.add_parser("ui_tap_find")
-    putf.add_argument("--text-contains", dest="text_contains", default="")
-    putf.add_argument("--desc-contains", dest="desc_contains", default="")
-    putf.add_argument("--resource-id-contains", dest="resource_id_contains", default="")
-    putf.add_argument("--class-contains", dest="class_contains", default="")
-    putf.add_argument("--clickable-only", action="store_true")
-    putf.add_argument("--enabled-only", action="store_true")
-    putf.add_argument("--limit", type=int, default=8)
-
-    # NEW: ui_type_find
-    puif = sub.add_parser("ui_type_find")
-    puif.add_argument("--text-contains", dest="text_contains", default="")
-    puif.add_argument("--desc-contains", dest="desc_contains", default="")
-    puif.add_argument("--resource-id-contains", dest="resource_id_contains", default="")
-    puif.add_argument("--class-contains", dest="class_contains", default="")
-    puif.add_argument("--enabled-only", action="store_true")
-    puif.add_argument("--limit", type=int, default=8)
-    puif.add_argument("--clear", action="store_true")
-    puif.add_argument("text")
-
-    pag = sub.add_parser("agent_task")
-    pag.add_argument("goal")
-    pag.add_argument("--steps", type=int, default=30)
-    pag.add_argument("--timeout", type=int, default=1000)
-    pag.add_argument("--device-serial", dest="device_serial", default="")
-    pag.add_argument("--tcp", action="store_true")
-
-    args = p.parse_args()
+    args = parser.parse_args()
 
     try:
         if args.cmd == "health":
             return cmd_health(args)
-        if args.cmd == "screenshot":
-            return cmd_screenshot(args)
-        if args.cmd == "tap":
-            return cmd_tap(args)
-        if args.cmd == "swipe":
-            return cmd_swipe(args)
-        if args.cmd == "type":
-            return cmd_type(args)
-        if args.cmd == "get_state":
-            return cmd_get_state(args)
-        if args.cmd == "ui_dump":
-            return cmd_ui_dump(args)
-        if args.cmd == "ui_tap":
-            return cmd_ui_tap(args)
-        if args.cmd == "ui_type":
-            return cmd_ui_type(args)
-        if args.cmd == "ui_find":
-            return cmd_ui_find(args)
-        if args.cmd == "ui_tap_find":
-            return cmd_ui_tap_find(args)
-        if args.cmd == "ui_type_find":
-            return cmd_ui_type_find(args)
         if args.cmd == "agent_task":
             return cmd_agent_task(args)
         return fail("unknown cmd")
-    except Exception as e:
-        return fail("exception", {"repr": repr(e)})
+    except KeyboardInterrupt:
+        return fail("interrupted", code=130)
+    except Exception as exc:
+        return fail("exception", {"repr": repr(exc)})
 
 
 if __name__ == "__main__":

--- a/openclaw-plugin-mobile-ui/src/backends/adb.ts
+++ b/openclaw-plugin-mobile-ui/src/backends/adb.ts
@@ -22,9 +22,14 @@ function adbCommandArgs(args: string[]) {
   return serial ? ["-s", serial, ...args] : args;
 }
 
-function runAdb(args: string[], timeoutMs = DEFAULT_TIMEOUT_MS): Promise<AdbResult> {
+function runAdb(
+  args: string[],
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  options?: { useSerial?: boolean }
+): Promise<AdbResult> {
   return new Promise((resolve) => {
-    const p = spawn("adb", adbCommandArgs(args), { env: process.env, stdio: ["ignore", "pipe", "pipe"] });
+    const adbArgs = options?.useSerial === false ? args : adbCommandArgs(args);
+    const p = spawn("adb", adbArgs, { env: process.env, stdio: ["ignore", "pipe", "pipe"] });
 
     let stdout = "";
     let stderr = "";
@@ -64,7 +69,7 @@ function encodeInputText(text: string) {
 }
 
 export async function adb_devices() {
-  const res = await runAdb(["devices", "-l"], 10_000);
+  const res = await runAdb(["devices", "-l"], 10_000, { useSerial: false });
   if (!res.ok) return { ...res, devices: [] };
 
   const lines = res.stdout.split(/\r?\n/).filter(Boolean);

--- a/openclaw-plugin-mobile-ui/src/backends/adb.ts
+++ b/openclaw-plugin-mobile-ui/src/backends/adb.ts
@@ -17,9 +17,14 @@ const DEFAULT_TIMEOUT_MS = 20_000;
 const DEFAULT_SCREENSHOT_TIMEOUT_MS = 30_000;
 const DEFAULT_TYPE_TIMEOUT_MS = 30_000;
 
+function adbCommandArgs(args: string[]) {
+  const serial = process.env.DROIDRUN_SERIAL || process.env.ANDROID_SERIAL || "";
+  return serial ? ["-s", serial, ...args] : args;
+}
+
 function runAdb(args: string[], timeoutMs = DEFAULT_TIMEOUT_MS): Promise<AdbResult> {
   return new Promise((resolve) => {
-    const p = spawn("adb", args, { env: process.env, stdio: ["ignore", "pipe", "pipe"] });
+    const p = spawn("adb", adbCommandArgs(args), { env: process.env, stdio: ["ignore", "pipe", "pipe"] });
 
     let stdout = "";
     let stderr = "";
@@ -127,7 +132,7 @@ export async function adb_ui_dump_xml(input: { compressed?: boolean }) {
 
 export async function adb_screenshot(input?: { timeoutMs?: number }) {
   return await new Promise((resolve) => {
-    const p = spawn("adb", ["exec-out", "screencap", "-p"], {
+    const p = spawn("adb", adbCommandArgs(["exec-out", "screencap", "-p"]), {
       env: process.env,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/openclaw-plugin-mobile-ui/src/backends/droidrun.ts
+++ b/openclaw-plugin-mobile-ui/src/backends/droidrun.ts
@@ -1,18 +1,15 @@
-import fs from "fs";
 import { DroidrunExecutor } from "../internal/droidrun/executor";
 import { DroidrunAgent } from "../internal/droidrun/agent";
 import { auditEnd, auditError, auditStart } from "../internal/runtime";
 import {
-  makeScreenshotPath,
-  pngDimensions,
-  truncateLargeStrings,
   ensureLogsDir,
   writeLog,
 } from "../tools/workspace";
 
 // DroidRun backend adapter.
-// This module owns serialized access to Portal-backed operations and exposes
-// backend-shaped helpers for the public `android_*` wrappers.
+// This module now keeps a deliberately small surface: health checks plus
+// agent-mode execution. Low-level device actions and deterministic UI dumps
+// live in the adb-backed path instead.
 
 const exec = new DroidrunExecutor();
 const agent = new DroidrunAgent();
@@ -64,123 +61,6 @@ export async function droidrun_health() {
   return withFailureLog("droidrun_health", res);
 }
 
-export async function droidrun_screenshot() {
-  const res = await audit("droidrun_screenshot", () =>
-    withPortal(async () => {
-    const outPath = makeScreenshotPath();
-    const res = await exec.screenshot(outPath);
-    const ok = (res as any)?.ok === true;
-    if (!ok) {
-      console.warn("[android_screenshot] droidrun screenshot failed");
-      return { ok: false, error: "droidrun_screenshot_failed", path: "", bytes: 0, width: 0, height: 0 };
-    }
-
-    try {
-      const buf = fs.readFileSync(outPath);
-      const dims = pngDimensions(buf);
-      console.log(`[android_screenshot] saved to ${outPath}. If attachments are unavailable, use the path.`);
-      return { ok: true, path: outPath, bytes: buf.length, width: dims.width, height: dims.height };
-    } catch (e: any) {
-      console.warn(`[android_screenshot] read failed: ${String(e?.message || e)}`);
-      return { ok: false, error: "droidrun_screenshot_read_failed", path: "", bytes: 0, width: 0, height: 0 };
-    }
-    })
-  );
-  return withFailureLog("droidrun_screenshot", res);
-}
-
-export async function droidrun_tap(x: number, y: number) {
-  const res = await audit("droidrun_tap", () => withPortal(() => exec.tap(x, y)));
-  return withFailureLog("droidrun_tap", res);
-}
-
-export async function droidrun_type(text: string, index = -1, clear = false) {
-  const res = await audit("droidrun_type", () => withPortal(() => exec.typeText(text, index, clear)));
-  return withFailureLog("droidrun_type", res);
-}
-
-export async function droidrun_swipe(x1: number, y1: number, x2: number, y2: number, durationMs = 300) {
-  const res = await audit("droidrun_swipe", () => withPortal(() => exec.swipe(x1, y1, x2, y2, durationMs)));
-  return withFailureLog("droidrun_swipe", res);
-}
-
-export async function droidrun_ui_dump() {
-  const res = await audit("droidrun_ui_dump", () =>
-    withPortal(async () => {
-    const res = await exec.uiDump();
-    const ok = (res as any)?.ok === true;
-    if (!ok) {
-      const logDir = ensureLogsDir();
-      const logPath = writeLog(
-        logDir,
-        "ui_dump",
-        JSON.stringify({ error: (res as any)?.error || "ui_dump_failed", res }, null, 2)
-      );
-      return { ok: false, error: "ui_dump_failed", logPath };
-    }
-    return truncateLargeStrings(res);
-    })
-  );
-  return withFailureLog("droidrun_ui_dump", res);
-}
-
-export async function droidrun_ui_tap(index: number) {
-  const res = await audit("droidrun_ui_tap", () => withPortal(() => exec.uiTap(index)));
-  return withFailureLog("droidrun_ui_tap", res);
-}
-
-export async function droidrun_ui_type(index: number, text: string, clear = false) {
-  const res = await audit("droidrun_ui_type", () => withPortal(() => exec.uiType(index, text, clear)));
-  return withFailureLog("droidrun_ui_type", res);
-}
-
-export async function droidrun_ui_find(input: {
-  textContains?: string;
-  descContains?: string;
-  resourceIdContains?: string;
-  classContains?: string;
-  clickableOnly?: boolean;
-  enabledOnly?: boolean;
-  preferClickable?: boolean;
-  limit?: number;
-}) {
-  const res = await audit("droidrun_ui_find", () =>
-    withPortal(async () => truncateLargeStrings(await exec.uiFind(input || {})))
-  );
-  return withFailureLog("droidrun_ui_find", res);
-}
-
-export async function droidrun_ui_tap_find(input: {
-  textContains?: string;
-  descContains?: string;
-  resourceIdContains?: string;
-  classContains?: string;
-  clickableOnly?: boolean;
-  enabledOnly?: boolean;
-  limit?: number;
-}) {
-  const res = await audit("droidrun_ui_tap_find", () =>
-    withPortal(async () => truncateLargeStrings(await exec.uiTapFind(input || {})))
-  );
-  return withFailureLog("droidrun_ui_tap_find", res);
-}
-
-export async function droidrun_ui_type_find(input: {
-  textContains?: string;
-  descContains?: string;
-  resourceIdContains?: string;
-  classContains?: string;
-  enabledOnly?: boolean;
-  limit?: number;
-  clear?: boolean;
-  text: string;
-}) {
-  const res = await audit("droidrun_ui_type_find", () =>
-    withPortal(async () => truncateLargeStrings(await exec.uiTypeFind(input || ({} as any))))
-  );
-  return withFailureLog("droidrun_ui_type_find", res);
-}
-
 export async function droidrun_agent_task(input: {
   goal: string;
   steps?: number;
@@ -190,6 +70,6 @@ export async function droidrun_agent_task(input: {
 }) {
   // TODO: keep agent-mode exposed here for now, but treat app/workflow policy
   // above this layer rather than inside backend adapters.
-  const res = await audit("droidrun_agent_task", () => agent.runTask(input));
+  const res = await audit("droidrun_agent_task", () => withPortal(() => agent.runTask(input)));
   return withFailureLog("droidrun_agent_task", res);
 }

--- a/openclaw-plugin-mobile-ui/src/index.ts
+++ b/openclaw-plugin-mobile-ui/src/index.ts
@@ -70,13 +70,7 @@ export default function register(api: any) {
     toolDef(
       "android_screenshot",
       "Take a screenshot on the Android device (via adb).",
-      {
-        type: "object",
-        properties: {
-          backend: { type: "string", enum: ["auto", "adb"] },
-        },
-        additionalProperties: false,
-      },
+      { type: "object", properties: {}, additionalProperties: false },
       async (args) => android_screenshot(args)
     )
   );
@@ -90,7 +84,6 @@ export default function register(api: any) {
         properties: {
           x: { type: "integer" },
           y: { type: "integer" },
-          backend: { type: "string", enum: ["auto", "adb"] },
         },
         required: ["x", "y"],
         additionalProperties: false,
@@ -107,7 +100,6 @@ export default function register(api: any) {
         type: "object",
         properties: {
           text: { type: "string" },
-          backend: { type: "string", enum: ["auto", "adb"] },
         },
         required: ["text"],
         additionalProperties: false,
@@ -128,7 +120,6 @@ export default function register(api: any) {
           x2: { type: "integer" },
           y2: { type: "integer" },
           durationMs: { type: "integer" },
-          backend: { type: "string", enum: ["auto", "adb"] },
         },
         required: ["x1", "y1", "x2", "y2"],
         additionalProperties: false,

--- a/openclaw-plugin-mobile-ui/src/index.ts
+++ b/openclaw-plugin-mobile-ui/src/index.ts
@@ -6,11 +6,6 @@ import {
   android_swipe,
   android_agent_task,
   android_ui_dump,
-  android_ui_tap,
-  android_ui_type,
-  android_ui_find,
-  android_ui_tap_find,
-  android_ui_type_find,
 } from "./tools/android";
 import { signalComplete as android_signal_complete } from "./tools/attention";
 import {
@@ -74,11 +69,11 @@ export default function register(api: any) {
   api.registerTool(
     toolDef(
       "android_screenshot",
-      "Take a screenshot on the Android device (via droidrun or adb).",
+      "Take a screenshot on the Android device (via adb).",
       {
         type: "object",
         properties: {
-          backend: { type: "string", enum: ["auto", "adb", "droidrun"] },
+          backend: { type: "string", enum: ["auto", "adb"] },
         },
         additionalProperties: false,
       },
@@ -89,13 +84,13 @@ export default function register(api: any) {
   api.registerTool(
     toolDef(
       "android_tap",
-      "Tap at (x,y) on the Android device (via droidrun or adb).",
+      "Tap at (x,y) on the Android device (via adb).",
       {
         type: "object",
         properties: {
           x: { type: "integer" },
           y: { type: "integer" },
-          backend: { type: "string", enum: ["auto", "adb", "droidrun"] },
+          backend: { type: "string", enum: ["auto", "adb"] },
         },
         required: ["x", "y"],
         additionalProperties: false,
@@ -107,14 +102,12 @@ export default function register(api: any) {
   api.registerTool(
     toolDef(
       "android_type",
-      "Type text into the focused field (via droidrun or adb). Optional index targets a11y element index.",
+      "Type text into the currently focused field (via adb).",
       {
         type: "object",
         properties: {
           text: { type: "string" },
-          index: { type: "integer" },
-          clear: { type: "boolean" },
-          backend: { type: "string", enum: ["auto", "adb", "droidrun"] },
+          backend: { type: "string", enum: ["auto", "adb"] },
         },
         required: ["text"],
         additionalProperties: false,
@@ -126,7 +119,7 @@ export default function register(api: any) {
   api.registerTool(
     toolDef(
       "android_swipe",
-      "Swipe from (x1,y1) to (x2,y2) (via droidrun or adb).",
+      "Swipe from (x1,y1) to (x2,y2) (via adb).",
       {
         type: "object",
         properties: {
@@ -135,7 +128,7 @@ export default function register(api: any) {
           x2: { type: "integer" },
           y2: { type: "integer" },
           durationMs: { type: "integer" },
-          backend: { type: "string", enum: ["auto", "adb", "droidrun"] },
+          backend: { type: "string", enum: ["auto", "adb"] },
         },
         required: ["x1", "y1", "x2", "y2"],
         additionalProperties: false,
@@ -144,49 +137,17 @@ export default function register(api: any) {
     )
   );
 
-  // ---- semantic UI tools (DroidRun-backed) ----
+  // ---- deterministic observation + DroidRun agent mode ----
   api.registerTool(
     toolDef(
       "android_ui_dump",
-      "Dump current UI accessibility nodes (a11y). Returns a list with indexes you can tap/type.",
+      "Dump current UI hierarchy using adb uiautomator XML. This is the default deterministic observation path.",
       {
         type: "object",
         properties: {},
         additionalProperties: false,
       },
       async () => android_ui_dump()
-    )
-  );
-
-  api.registerTool(
-    toolDef(
-      "android_ui_tap",
-      "Tap an element by accessibility index (stable across screen sizes vs coordinates).",
-      {
-        type: "object",
-        properties: { index: { type: "integer" } },
-        required: ["index"],
-        additionalProperties: false,
-      },
-      async (args) => android_ui_tap(args)
-    )
-  );
-
-  api.registerTool(
-    toolDef(
-      "android_ui_type",
-      "Type text into an element by accessibility index.",
-      {
-        type: "object",
-        properties: {
-          index: { type: "integer" },
-          text: { type: "string" },
-          clear: { type: "boolean" },
-        },
-        required: ["index", "text"],
-        additionalProperties: false,
-      },
-      async (args) => android_ui_type(args)
     )
   );
 
@@ -207,72 +168,6 @@ export default function register(api: any) {
         additionalProperties: false
       },
       async (args) => android_agent_task(args)
-    )
-  );
-
-  api.registerTool(
-    toolDef(
-      "android_ui_find",
-      "Find UI accessibility nodes by text/resource-id/desc/class. Returns ranked candidates with indexes.",
-      {
-        type: "object",
-        properties: {
-          textContains: { type: "string" },
-          descContains: { type: "string" },
-          resourceIdContains: { type: "string" },
-          classContains: { type: "string" },
-          clickableOnly: { type: "boolean" },
-          enabledOnly: { type: "boolean" },
-          preferClickable: { type: "boolean" },
-          limit: { type: "integer" },
-        },
-        additionalProperties: false,
-      },
-      async (args) => android_ui_find(args)
-    )
-  );
-
-  api.registerTool(
-    toolDef(
-      "android_ui_tap_find",
-      "Find a UI element by text/resource-id/desc/class and tap the best match.",
-      {
-        type: "object",
-        properties: {
-          textContains: { type: "string" },
-          descContains: { type: "string" },
-          resourceIdContains: { type: "string" },
-          classContains: { type: "string" },
-          clickableOnly: { type: "boolean" },
-          enabledOnly: { type: "boolean" },
-          limit: { type: "integer" }
-        },
-        additionalProperties: false
-      },
-      async (args) => android_ui_tap_find(args)
-    )
-  );
-
-  api.registerTool(
-    toolDef(
-      "android_ui_type_find",
-      "Find a UI input field and type text into it.",
-      {
-        type: "object",
-        properties: {
-          textContains: { type: "string" },
-          descContains: { type: "string" },
-          resourceIdContains: { type: "string" },
-          classContains: { type: "string" },
-          enabledOnly: { type: "boolean" },
-          limit: { type: "integer" },
-          clear: { type: "boolean" },
-          text: { type: "string" }
-        },
-        required: ["text"],
-        additionalProperties: false
-      },
-      async (args) => android_ui_type_find(args)
     )
   );
 

--- a/openclaw-plugin-mobile-ui/src/index.ts
+++ b/openclaw-plugin-mobile-ui/src/index.ts
@@ -71,7 +71,7 @@ export default function register(api: any) {
       "android_screenshot",
       "Take a screenshot on the Android device (via adb).",
       { type: "object", properties: {}, additionalProperties: false },
-      async (args) => android_screenshot(args)
+      async () => android_screenshot()
     )
   );
 

--- a/openclaw-plugin-mobile-ui/src/internal/droidrun/agent.ts
+++ b/openclaw-plugin-mobile-ui/src/internal/droidrun/agent.ts
@@ -71,27 +71,42 @@ function runPython(args: string[], timeoutMs = 120_000): Promise<ExecResult> {
 
     p.on("close", (code) => {
       clearTimeout(timer);
+      const exitCode = typeof code === "number" ? code : -1;
       const parsed = parseJsonFromStdout(out);
-      if (parsed && typeof parsed === "object") {
-        parsed.extra = { ...(parsed.extra || {}), exit_code: code };
+
+      if (parsed && typeof parsed === "object" && typeof parsed.ok === "boolean") {
+        if (err) {
+          parsed.extra = { ...(parsed.extra || {}), stderr_snip: truncate(err) };
+        }
+        parsed.extra = { ...(parsed.extra || {}), exit_code: exitCode };
         resolve(parsed);
         return;
       }
 
-      const exitCode = typeof code === "number" ? code : -1;
-      if (exitCode === 0) {
+      if (!(out || "").trim()) {
         resolve({
-          ok: true,
-          data: { output: (out || "").trim() },
-          extra: { stdout: truncate(out), stderr: truncate(err), exit_code: exitCode, output_format: "text" },
+          ok: false,
+          error: "empty_output",
+          extra: {
+            stderr: truncate(err),
+            stderr_snip: truncate(err),
+            exit_code: exitCode,
+            output_format: "text",
+          },
         });
         return;
       }
 
       resolve({
         ok: false,
-        error: "python_failed",
-        extra: { stdout: truncate(out), stderr: truncate(err), exit_code: exitCode, output_format: "text" },
+        error: exitCode === 0 ? "invalid_json" : "python_failed",
+        extra: {
+          stdout: truncate(out),
+          stderr: truncate(err),
+          stderr_snip: truncate(err),
+          exit_code: exitCode,
+          output_format: "text",
+        },
       });
     });
   });
@@ -108,7 +123,6 @@ export class DroidrunAgent {
     const args: string[] = ["agent_task", input.goal];
 
     if (typeof input.steps === "number") args.push("--steps", String(input.steps));
-    if (typeof input.timeout === "number") args.push("--timeout", String(input.timeout));
     if (input.deviceSerial) args.push("--device-serial", input.deviceSerial);
     if (input.tcp) args.push("--tcp");
 

--- a/openclaw-plugin-mobile-ui/src/internal/droidrun/agent.ts
+++ b/openclaw-plugin-mobile-ui/src/internal/droidrun/agent.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
 import path from "path";
+import { parseJsonFromStdout } from "./protocol";
 
 type ExecResult = { ok: boolean; data?: any; error?: string; extra?: any };
 
@@ -21,24 +22,6 @@ function buildEnv(py: string) {
 function truncate(s: string, max = 4000) {
   if (!s) return "";
   return s.length > max ? s.slice(0, max) : s;
-}
-
-function parseJsonFromStdout(stdout: string): any | null {
-  const trimmed = (stdout || "").trim();
-  if (!trimmed) return null;
-
-  try {
-    return JSON.parse(trimmed);
-  } catch {}
-
-  const lines = trimmed.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    try {
-      return JSON.parse(lines[i]);
-    } catch {}
-  }
-
-  return null;
 }
 
 function runPython(args: string[], timeoutMs = 120_000): Promise<ExecResult> {

--- a/openclaw-plugin-mobile-ui/src/internal/droidrun/executor.ts
+++ b/openclaw-plugin-mobile-ui/src/internal/droidrun/executor.ts
@@ -1,29 +1,12 @@
 import { spawn } from "child_process";
 import path from "path";
+import { parseJsonFromStdout } from "./protocol";
 
 export type ExecResult = { ok: boolean; data?: any; error?: string; extra?: any };
 
 function truncate(s: string, max = 2000) {
   if (!s) return "";
   return s.length > max ? s.slice(0, max) : s;
-}
-
-function parseJsonFromStdout(stdout: string): any | null {
-  const trimmed = (stdout || "").trim();
-  if (!trimmed) return null;
-
-  try {
-    return JSON.parse(trimmed);
-  } catch {}
-
-  const lines = trimmed.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    try {
-      return JSON.parse(lines[i]);
-    } catch {}
-  }
-
-  return null;
 }
 
 function buildEnv(py: string) {

--- a/openclaw-plugin-mobile-ui/src/internal/droidrun/executor.ts
+++ b/openclaw-plugin-mobile-ui/src/internal/droidrun/executor.ts
@@ -8,6 +8,24 @@ function truncate(s: string, max = 2000) {
   return s.length > max ? s.slice(0, max) : s;
 }
 
+function parseJsonFromStdout(stdout: string): any | null {
+  const trimmed = (stdout || "").trim();
+  if (!trimmed) return null;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {}
+
+  const lines = trimmed.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    try {
+      return JSON.parse(lines[i]);
+    } catch {}
+  }
+
+  return null;
+}
+
 function buildEnv(py: string) {
   return {
     ...process.env,
@@ -49,22 +67,32 @@ function runPython(args: string[], timeoutMs = 30_000): Promise<ExecResult> {
 
     p.on("close", (code) => {
       clearTimeout(timer);
-      try {
-        const parsed = JSON.parse((out || "").trim() || "{}");
-        if (parsed && typeof parsed === "object" && err) {
+      const exitCode = typeof code === "number" ? code : -1;
+      const parsed = parseJsonFromStdout(out);
+
+      if (parsed && typeof parsed === "object" && typeof parsed.ok === "boolean") {
+        if (err) {
           parsed.extra = { ...(parsed.extra || {}), stderr_snip: truncate(err) };
         }
-        if (parsed && typeof parsed === "object") {
-          parsed.extra = { ...(parsed.extra || {}), exit_code: code };
-        }
+        parsed.extra = { ...(parsed.extra || {}), exit_code: exitCode };
         resolve(parsed);
-      } catch {
+        return;
+      }
+
+      if (!(out || "").trim()) {
         resolve({
           ok: false,
-          error: "invalid_json",
-          extra: { stdout: truncate(out), stderr: truncate(err), stderr_snip: truncate(err), exit_code: code },
+          error: "empty_output",
+          extra: { stderr: truncate(err), stderr_snip: truncate(err), exit_code: exitCode },
         });
+        return;
       }
+
+      resolve({
+        ok: false,
+        error: exitCode === 0 ? "invalid_json" : "python_failed",
+        extra: { stdout: truncate(out), stderr: truncate(err), stderr_snip: truncate(err), exit_code: exitCode },
+      });
     });
   });
 }
@@ -72,112 +100,5 @@ function runPython(args: string[], timeoutMs = 30_000): Promise<ExecResult> {
 export class DroidrunExecutor {
   async health() {
     return runPython(["health"], 10_000);
-  }
-
-  async screenshot(output?: string) {
-    const args = ["screenshot"];
-    if (output) args.push("--output", output);
-    return runPython(args, 60_000);
-  }
-
-  async tap(x: number, y: number) {
-    return runPython(["tap", String(x), String(y)]);
-  }
-
-  async typeText(text: string, index = -1, clear = false) {
-    const args = ["type", text, "--index", String(index)];
-    if (clear) args.push("--clear");
-    return runPython(args, 60_000);
-  }
-
-  async swipe(x1: number, y1: number, x2: number, y2: number, durationMs = 300) {
-    return runPython(
-      ["swipe", String(x1), String(y1), String(x2), String(y2), "--duration-ms", String(durationMs)],
-      60_000
-    );
-  }
-
-  // ---- NEW: ui dump / tap / type (a11y index based) ----
-  async uiDump() {
-    const args = ["ui_dump"];
-    return runPython(args, 30_000);
-  }
-
-  async uiTap(index: number) {
-    return runPython(["ui_tap", String(index)], 30_000);
-  }
-
-  async uiType(index: number, text: string, clear = false) {
-    const args = ["ui_type", String(index), text];
-    if (clear) args.push("--clear");
-    return runPython(args, 60_000);
-  }
-
-  async uiFind(q: {
-    textContains?: string;
-    descContains?: string;
-    resourceIdContains?: string;
-    classContains?: string;
-    clickableOnly?: boolean;
-    enabledOnly?: boolean;
-    preferClickable?: boolean;
-    limit?: number;
-  }) {
-    const args: string[] = ["ui_find"];
-
-    if (q?.textContains) args.push("--text-contains", q.textContains);
-    if (q?.descContains) args.push("--desc-contains", q.descContains);
-    if (q?.resourceIdContains) args.push("--resource-id-contains", q.resourceIdContains);
-    if (q?.classContains) args.push("--class-contains", q.classContains);
-
-    if (q?.clickableOnly) args.push("--clickable-only");
-    if (q?.enabledOnly) args.push("--enabled-only");
-    if (q?.preferClickable) args.push("--prefer-clickable");
-
-    if (typeof q?.limit === "number") args.push("--limit", String(q.limit));
-
-    return runPython(args, 30_000);
-  }
-
-  async uiTapFind(q: {
-    textContains?: string;
-    descContains?: string;
-    resourceIdContains?: string;
-    classContains?: string;
-    clickableOnly?: boolean;
-    enabledOnly?: boolean;
-    limit?: number;
-  }) {
-    const args: string[] = ["ui_tap_find"];
-    if (q?.textContains) args.push("--text-contains", q.textContains);
-    if (q?.descContains) args.push("--desc-contains", q.descContains);
-    if (q?.resourceIdContains) args.push("--resource-id-contains", q.resourceIdContains);
-    if (q?.classContains) args.push("--class-contains", q.classContains);
-    if (q?.clickableOnly) args.push("--clickable-only");
-    if (q?.enabledOnly) args.push("--enabled-only");
-    if (typeof q?.limit === "number") args.push("--limit", String(q.limit));
-    return runPython(args, 30_000);
-  }
-
-  async uiTypeFind(q: {
-    textContains?: string;
-    descContains?: string;
-    resourceIdContains?: string;
-    classContains?: string;
-    enabledOnly?: boolean;
-    limit?: number;
-    clear?: boolean;
-    text: string;
-  }) {
-    const args: string[] = ["ui_type_find"];
-    if (q?.textContains) args.push("--text-contains", q.textContains);
-    if (q?.descContains) args.push("--desc-contains", q.descContains);
-    if (q?.resourceIdContains) args.push("--resource-id-contains", q.resourceIdContains);
-    if (q?.classContains) args.push("--class-contains", q.classContains);
-    if (q?.enabledOnly) args.push("--enabled-only");
-    if (typeof q?.limit === "number") args.push("--limit", String(q.limit));
-    if (q?.clear) args.push("--clear");
-    args.push(q.text ?? "");
-    return runPython(args, 60_000);
   }
 }

--- a/openclaw-plugin-mobile-ui/src/internal/droidrun/protocol.ts
+++ b/openclaw-plugin-mobile-ui/src/internal/droidrun/protocol.ts
@@ -1,0 +1,20 @@
+export function parseJsonFromStdout(stdout: string): any | null {
+  const trimmed = (stdout || "").trim();
+  if (!trimmed) return null;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {}
+
+  const lines = trimmed
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    try {
+      return JSON.parse(lines[i]);
+    } catch {}
+  }
+
+  return null;
+}

--- a/openclaw-plugin-mobile-ui/src/internal/runtime.ts
+++ b/openclaw-plugin-mobile-ui/src/internal/runtime.ts
@@ -1,6 +1,8 @@
 import { appendToolAudit } from "../tools/workspace";
 
 export type CompositeBackend = "auto" | "adb" | "droidrun";
+export type LowLevelBackend = "auto" | "adb";
+export type ResolvedBackend = "adb" | "droidrun" | "unsupported";
 
 export function runtimeEnvFlags() {
   return {
@@ -56,8 +58,7 @@ export function auditError(tool: string, start: number, error: unknown, extra?: 
 export async function runWithBackendFallback(args: {
   backend?: CompositeBackend;
   adbAction: () => Promise<any>;
-  adbAutoAction?: () => Promise<any>;
-  droidrunAction: () => Promise<any>;
+  droidrunAction?: () => Promise<any>;
 }) {
   const backend = args.backend ?? "auto";
 
@@ -66,15 +67,27 @@ export async function runWithBackendFallback(args: {
   }
 
   if (backend === "droidrun") {
+    if (!args.droidrunAction) {
+      return {
+        res: {
+          ok: false,
+          error: "droidrun_backend_not_supported_for_low_level_action",
+          extra: { requested_backend: "droidrun" },
+        },
+        resolvedBackend: "unsupported" as const,
+      };
+    }
     return { res: await args.droidrunAction(), resolvedBackend: "droidrun" as const };
   }
 
-  // In auto mode, prefer a direct ADB attempt over a separate preflight probe.
-  // This removes one extra subprocess from the common success path, but use a
-  // shorter ADB attempt here so fallback stays responsive when ADB is stale,
-  // unauthorized, or unavailable.
-  const adbRes = await (args.adbAutoAction ?? args.adbAction)();
+  // In auto mode, try the normal adb action first. If a caller still provides
+  // a DroidRun fallback, only use it after the adb path fails.
+  const adbRes = await args.adbAction();
   if ((adbRes as any)?.ok) {
+    return { res: adbRes, resolvedBackend: "adb" as const };
+  }
+
+  if (!args.droidrunAction) {
     return { res: adbRes, resolvedBackend: "adb" as const };
   }
 

--- a/openclaw-plugin-mobile-ui/src/internal/runtime.ts
+++ b/openclaw-plugin-mobile-ui/src/internal/runtime.ts
@@ -1,7 +1,6 @@
 import { appendToolAudit } from "../tools/workspace";
 
 export type CompositeBackend = "auto" | "adb" | "droidrun";
-export type LowLevelBackend = "auto" | "adb";
 export type ResolvedBackend = "adb" | "droidrun" | "unsupported";
 
 export function runtimeEnvFlags() {
@@ -53,43 +52,4 @@ export function auditError(tool: string, start: number, error: unknown, extra?: 
     error: String((error as any)?.message || error || "unknown_error"),
     ...(extra || {}),
   });
-}
-
-export async function runWithBackendFallback(args: {
-  backend?: CompositeBackend;
-  adbAction: () => Promise<any>;
-  droidrunAction?: () => Promise<any>;
-}) {
-  const backend = args.backend ?? "auto";
-
-  if (backend === "adb") {
-    return { res: await args.adbAction(), resolvedBackend: "adb" as const };
-  }
-
-  if (backend === "droidrun") {
-    if (!args.droidrunAction) {
-      return {
-        res: {
-          ok: false,
-          error: "droidrun_backend_not_supported_for_low_level_action",
-          extra: { requested_backend: "droidrun" },
-        },
-        resolvedBackend: "unsupported" as const,
-      };
-    }
-    return { res: await args.droidrunAction(), resolvedBackend: "droidrun" as const };
-  }
-
-  // In auto mode, try the normal adb action first. If a caller still provides
-  // a DroidRun fallback, only use it after the adb path fails.
-  const adbRes = await args.adbAction();
-  if ((adbRes as any)?.ok) {
-    return { res: adbRes, resolvedBackend: "adb" as const };
-  }
-
-  if (!args.droidrunAction) {
-    return { res: adbRes, resolvedBackend: "adb" as const };
-  }
-
-  return { res: await args.droidrunAction(), resolvedBackend: "droidrun" as const };
 }

--- a/openclaw-plugin-mobile-ui/src/internal/runtime.ts
+++ b/openclaw-plugin-mobile-ui/src/internal/runtime.ts
@@ -1,8 +1,5 @@
 import { appendToolAudit } from "../tools/workspace";
 
-export type CompositeBackend = "auto" | "adb" | "droidrun";
-export type ResolvedBackend = "adb" | "droidrun" | "unsupported";
-
 export function runtimeEnvFlags() {
   return {
     DROIDRUN_SERIAL: process.env.DROIDRUN_SERIAL || "",

--- a/openclaw-plugin-mobile-ui/src/tools/android.ts
+++ b/openclaw-plugin-mobile-ui/src/tools/android.ts
@@ -3,8 +3,6 @@ import {
   auditEnd,
   auditError,
   auditStart,
-  LowLevelBackend,
-  runWithBackendFallback,
 } from "../internal/runtime";
 import { signalComplete } from "./attention";
 import {
@@ -21,44 +19,35 @@ export async function android_health() {
   return droidrun_health();
 }
 
-export async function android_screenshot(input: { backend?: LowLevelBackend }) {
+export async function android_screenshot() {
   const start = Date.now();
-  const backend = input?.backend ?? "auto";
-  auditStart("android_screenshot", backend, start);
+  auditStart("android_screenshot", "adb", start);
   try {
-    const { res, resolvedBackend } = await runWithBackendFallback({
-      backend,
-      adbAction: () => adb_screenshot(),
-    });
-    auditEnd("android_screenshot", start, res, { resolved_backend: resolvedBackend });
+    const res = await adb_screenshot();
+    auditEnd("android_screenshot", start, res, { resolved_backend: "adb" });
     return res;
   } catch (error) {
-    auditError("android_screenshot", start, error, { backend });
+    auditError("android_screenshot", start, error, { backend: "adb" });
     throw error;
   }
 }
 
-export async function android_tap(input: { x: number; y: number; backend?: LowLevelBackend }) {
+export async function android_tap(input: { x: number; y: number }) {
   const start = Date.now();
-  const backend = input?.backend ?? "auto";
-  auditStart("android_tap", backend, start);
+  auditStart("android_tap", "adb", start);
   try {
-    const { res, resolvedBackend } = await runWithBackendFallback({
-      backend,
-      adbAction: () => adb_tap({ x: input.x, y: input.y }),
-    });
-    auditEnd("android_tap", start, res, { resolved_backend: resolvedBackend });
+    const res = await adb_tap({ x: input.x, y: input.y });
+    auditEnd("android_tap", start, res, { resolved_backend: "adb" });
     return res;
   } catch (error) {
-    auditError("android_tap", start, error, { backend });
+    auditError("android_tap", start, error, { backend: "adb" });
     throw error;
   }
 }
 
-export async function android_type(input: { text: string; backend?: LowLevelBackend }) {
+export async function android_type(input: { text: string }) {
   const start = Date.now();
-  const backend = input?.backend ?? "auto";
-  auditStart("android_type", backend, start);
+  auditStart("android_type", "adb", start);
   try {
     const legacyInput = input as any;
     if (legacyInput?.index !== undefined || legacyInput?.clear !== undefined) {
@@ -74,20 +63,17 @@ export async function android_type(input: { text: string; backend?: LowLevelBack
       };
       auditEnd("android_type", start, res, {
         resolved_backend: "unsupported",
-        requested_backend: backend,
+        requested_backend: "adb",
         rejection_reason: "legacy_index_or_clear_not_supported_in_adb_only_mode",
       });
       return res;
     }
 
-    const { res, resolvedBackend } = await runWithBackendFallback({
-      backend,
-      adbAction: () => adb_type({ text: input.text }),
-    });
-    auditEnd("android_type", start, res, { resolved_backend: resolvedBackend });
+    const res = await adb_type({ text: input.text });
+    auditEnd("android_type", start, res, { resolved_backend: "adb" });
     return res;
   } catch (error) {
-    auditError("android_type", start, error, { backend });
+    auditError("android_type", start, error, { backend: "adb" });
     throw error;
   }
 }
@@ -98,20 +84,15 @@ export async function android_swipe(input: {
   x2: number;
   y2: number;
   durationMs?: number;
-  backend?: LowLevelBackend;
 }) {
   const start = Date.now();
-  const backend = input?.backend ?? "auto";
-  auditStart("android_swipe", backend, start);
+  auditStart("android_swipe", "adb", start);
   try {
-    const { res, resolvedBackend } = await runWithBackendFallback({
-      backend,
-      adbAction: () => adb_swipe(input),
-    });
-    auditEnd("android_swipe", start, res, { resolved_backend: resolvedBackend });
+    const res = await adb_swipe(input);
+    auditEnd("android_swipe", start, res, { resolved_backend: "adb" });
     return res;
   } catch (error) {
-    auditError("android_swipe", start, error, { backend });
+    auditError("android_swipe", start, error, { backend: "adb" });
     throw error;
   }
 }
@@ -122,8 +103,15 @@ export async function android_ui_dump() {
   auditStart("android_ui_dump", "adb", start);
   try {
     const res = await adb_ui_dump_xml({});
-    auditEnd("android_ui_dump", start, res);
-    return { ...res, source: "adb_ui_dump_xml" };
+    const shaped = {
+      ok: res.ok,
+      code: res.code,
+      stderr: res.stderr,
+      xml: res.xml,
+      source: "adb_ui_dump_xml" as const,
+    };
+    auditEnd("android_ui_dump", start, shaped);
+    return shaped;
   } catch (error) {
     auditError("android_ui_dump", start, error, { backend: "adb" });
     throw error;

--- a/openclaw-plugin-mobile-ui/src/tools/android.ts
+++ b/openclaw-plugin-mobile-ui/src/tools/android.ts
@@ -4,6 +4,7 @@ import {
   auditError,
   auditStart,
 } from "../internal/runtime";
+import { truncateString } from "./workspace";
 import { signalComplete } from "./attention";
 import {
   droidrun_health,
@@ -45,19 +46,27 @@ export async function android_tap(input: { x: number; y: number }) {
   }
 }
 
-export async function android_type(input: { text: string }) {
+type AndroidTypeInput = {
+  text: string;
+  // Deprecated legacy fields from the old DroidRun-backed contract.
+  // We still accept them at runtime so older callers get a structured
+  // rejection instead of silently ignoring the request.
+  index?: number;
+  clear?: boolean;
+};
+
+export async function android_type(input: AndroidTypeInput) {
   const start = Date.now();
   auditStart("android_type", "adb", start);
   try {
-    const legacyInput = input as any;
-    if (legacyInput?.index !== undefined || legacyInput?.clear !== undefined) {
+    if (input.index !== undefined || input.clear !== undefined) {
       const res = {
         ok: false,
         error: "android_type_only_supports_typing_into_the_focused_field",
         extra: {
           unsupported_fields: [
-            ...(legacyInput?.index !== undefined ? ["index"] : []),
-            ...(legacyInput?.clear !== undefined ? ["clear"] : []),
+            ...(input.index !== undefined ? ["index"] : []),
+            ...(input.clear !== undefined ? ["clear"] : []),
           ],
         },
       };
@@ -109,6 +118,9 @@ export async function android_ui_dump() {
       stderr: res.stderr,
       xml: res.xml,
       source: "adb_ui_dump_xml" as const,
+      ...(!res.ok && res.stdout
+        ? { stdout_snip: truncateString(res.stdout) }
+        : {}),
     };
     auditEnd("android_ui_dump", start, shaped);
     return shaped;

--- a/openclaw-plugin-mobile-ui/src/tools/android.ts
+++ b/openclaw-plugin-mobile-ui/src/tools/android.ts
@@ -1,22 +1,16 @@
-import { adb_screenshot, adb_tap, adb_type, adb_swipe } from "../backends/adb";
-import { auditEnd, auditError, auditStart, CompositeBackend, runWithBackendFallback } from "../internal/runtime";
+import { adb_screenshot, adb_tap, adb_type, adb_swipe, adb_ui_dump_xml } from "../backends/adb";
+import {
+  auditEnd,
+  auditError,
+  auditStart,
+  LowLevelBackend,
+  runWithBackendFallback,
+} from "../internal/runtime";
 import { signalComplete } from "./attention";
 import {
   droidrun_health,
-  droidrun_screenshot,
-  droidrun_tap,
-  droidrun_type,
-  droidrun_swipe,
-  droidrun_ui_dump,
-  droidrun_ui_tap,
-  droidrun_ui_type,
-  droidrun_ui_find,
-  droidrun_ui_tap_find,
-  droidrun_ui_type_find,
   droidrun_agent_task,
 } from "../backends/droidrun";
-
-const AUTO_ADB_TIMEOUT_MS = 5_000;
 
 // Composite mobile runtime wrappers.
 // These are the higher-level tool implementations exposed as `android_*`.
@@ -27,17 +21,14 @@ export async function android_health() {
   return droidrun_health();
 }
 
-export async function android_screenshot(input: { backend?: CompositeBackend }) {
+export async function android_screenshot(input: { backend?: LowLevelBackend }) {
   const start = Date.now();
   const backend = input?.backend ?? "auto";
   auditStart("android_screenshot", backend, start);
   try {
-    // TODO: move backend-selection policy out of runtime wrappers into a narrower execution layer.
     const { res, resolvedBackend } = await runWithBackendFallback({
       backend,
       adbAction: () => adb_screenshot(),
-      adbAutoAction: () => adb_screenshot({ timeoutMs: AUTO_ADB_TIMEOUT_MS }),
-      droidrunAction: () => droidrun_screenshot(),
     });
     auditEnd("android_screenshot", start, res, { resolved_backend: resolvedBackend });
     return res;
@@ -47,7 +38,7 @@ export async function android_screenshot(input: { backend?: CompositeBackend }) 
   }
 }
 
-export async function android_tap(input: { x: number; y: number; backend?: CompositeBackend }) {
+export async function android_tap(input: { x: number; y: number; backend?: LowLevelBackend }) {
   const start = Date.now();
   const backend = input?.backend ?? "auto";
   auditStart("android_tap", backend, start);
@@ -55,8 +46,6 @@ export async function android_tap(input: { x: number; y: number; backend?: Compo
     const { res, resolvedBackend } = await runWithBackendFallback({
       backend,
       adbAction: () => adb_tap({ x: input.x, y: input.y }),
-      adbAutoAction: () => adb_tap({ x: input.x, y: input.y, timeoutMs: AUTO_ADB_TIMEOUT_MS }),
-      droidrunAction: () => droidrun_tap(input.x, input.y),
     });
     auditEnd("android_tap", start, res, { resolved_backend: resolvedBackend });
     return res;
@@ -66,21 +55,34 @@ export async function android_tap(input: { x: number; y: number; backend?: Compo
   }
 }
 
-export async function android_type(input: {
-  text: string;
-  index?: number;
-  clear?: boolean;
-  backend?: CompositeBackend;
-}) {
+export async function android_type(input: { text: string; backend?: LowLevelBackend }) {
   const start = Date.now();
   const backend = input?.backend ?? "auto";
   auditStart("android_type", backend, start);
   try {
+    const legacyInput = input as any;
+    if (legacyInput?.index !== undefined || legacyInput?.clear !== undefined) {
+      const res = {
+        ok: false,
+        error: "android_type_only_supports_typing_into_the_focused_field",
+        extra: {
+          unsupported_fields: [
+            ...(legacyInput?.index !== undefined ? ["index"] : []),
+            ...(legacyInput?.clear !== undefined ? ["clear"] : []),
+          ],
+        },
+      };
+      auditEnd("android_type", start, res, {
+        resolved_backend: "unsupported",
+        requested_backend: backend,
+        rejection_reason: "legacy_index_or_clear_not_supported_in_adb_only_mode",
+      });
+      return res;
+    }
+
     const { res, resolvedBackend } = await runWithBackendFallback({
       backend,
       adbAction: () => adb_type({ text: input.text }),
-      adbAutoAction: () => adb_type({ text: input.text, timeoutMs: AUTO_ADB_TIMEOUT_MS }),
-      droidrunAction: () => droidrun_type(input.text, input.index ?? -1, input.clear ?? false),
     });
     auditEnd("android_type", start, res, { resolved_backend: resolvedBackend });
     return res;
@@ -96,7 +98,7 @@ export async function android_swipe(input: {
   x2: number;
   y2: number;
   durationMs?: number;
-  backend?: CompositeBackend;
+  backend?: LowLevelBackend;
 }) {
   const start = Date.now();
   const backend = input?.backend ?? "auto";
@@ -105,8 +107,6 @@ export async function android_swipe(input: {
     const { res, resolvedBackend } = await runWithBackendFallback({
       backend,
       adbAction: () => adb_swipe(input),
-      adbAutoAction: () => adb_swipe({ ...input, timeoutMs: AUTO_ADB_TIMEOUT_MS }),
-      droidrunAction: () => droidrun_swipe(input.x1, input.y1, input.x2, input.y2, input.durationMs ?? 300),
     });
     auditEnd("android_swipe", start, res, { resolved_backend: resolvedBackend });
     return res;
@@ -116,29 +116,18 @@ export async function android_swipe(input: {
   }
 }
 
-// ---- semantic UI wrappers ----
+// ---- observation + agent wrappers ----
 export async function android_ui_dump() {
   const start = Date.now();
-  auditStart("android_ui_dump", "droidrun", start);
+  auditStart("android_ui_dump", "adb", start);
   try {
-    const res = await droidrun_ui_dump();
+    const res = await adb_ui_dump_xml({});
     auditEnd("android_ui_dump", start, res);
-    if ((res as any)?.error === "timeout") {
-      return { ok: false, error: "timeout", elapsed_s: Math.round((Date.now() - start) / 1000), timeout_s: undefined, logPath: (res as any)?.logPath };
-    }
-    return res;
+    return { ...res, source: "adb_ui_dump_xml" };
   } catch (error) {
-    auditError("android_ui_dump", start, error, { backend: "droidrun" });
+    auditError("android_ui_dump", start, error, { backend: "adb" });
     throw error;
   }
-}
-
-export async function android_ui_tap(input: { index: number }) {
-  return droidrun_ui_tap(input.index);
-}
-
-export async function android_ui_type(input: { index: number; text: string; clear?: boolean }) {
-  return droidrun_ui_type(input.index, input.text, input.clear ?? false);
 }
 
 export async function android_agent_task(input: {
@@ -166,44 +155,6 @@ export async function android_agent_task(input: {
     auditError("android_agent_task", start, error, { backend: "droidrun" });
     throw error;
   }
-}
-
-export async function android_ui_find(input: {
-  textContains?: string;
-  descContains?: string;
-  resourceIdContains?: string;
-  classContains?: string;
-  clickableOnly?: boolean;
-  enabledOnly?: boolean;
-  preferClickable?: boolean;
-  limit?: number;
-}) {
-  return droidrun_ui_find(input || {});
-}
-
-export async function android_ui_tap_find(input: {
-  textContains?: string;
-  descContains?: string;
-  resourceIdContains?: string;
-  classContains?: string;
-  clickableOnly?: boolean;
-  enabledOnly?: boolean;
-  limit?: number;
-}) {
-  return droidrun_ui_tap_find(input || {});
-}
-
-export async function android_ui_type_find(input: {
-  textContains?: string;
-  descContains?: string;
-  resourceIdContains?: string;
-  classContains?: string;
-  enabledOnly?: boolean;
-  limit?: number;
-  clear?: boolean;
-  text: string;
-}) {
-  return droidrun_ui_type_find(input || ({} as any));
 }
 
 export async function android_signal_complete(args?: {


### PR DESCRIPTION
* fix: support newer droidrun tools interfaces

* fix: rewrite portal ui bridge for newer droidrun

* fix: align droidrun ui integration with newer interfaces

* fix: use androiddriver path for droidrun ui state

* fix: use android state provider for droidrun ui dump

* fix the timeout

* refactor: default ui observation to adb xml

* fix: tighten mobile runtime follow-ups

* fix: tighten low-level android tool contracts

* fix: align mobile runtime error handling

* fix: finalize droidrun runtime consistency