### PR TITLE
perf: cache `ensureScreenshotsDir`/`ensureLogsDir` to avoid repeated `mkdirSync`

### DIFF
--- a/openclaw-plugin-mobile-ui/scripts/bench-dir-cache.mjs
+++ b/openclaw-plugin-mobile-ui/scripts/bench-dir-cache.mjs
@@ -1,0 +1,70 @@
+/**
+ * bench-dir-cache.mjs
+ *
+ * Benchmarks the cost of calling mkdirSync on every invocation (old behaviour)
+ * vs. caching the path and calling mkdirSync only once (new behaviour).
+ *
+ * Run from the repo root or the plugin directory:
+ *   node openclaw-plugin-mobile-ui/scripts/bench-dir-cache.mjs
+ *
+ * On Android/proot the effect is most pronounced (~5-30 ms per mkdirSync call).
+ * Run it there too to capture realistic numbers for the PR.
+ */
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const ITERATIONS = Number(process.argv[2]) || 1000;
+const TEST_DIR = path.join(os.tmpdir(), `bench_dir_cache_${process.pid}`);
+
+fs.mkdirSync(TEST_DIR, { recursive: true });
+
+// ── OLD: mkdirSync on every call ────────────────────────────────────────────
+function ensureDir_OLD(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ── NEW: mkdirSync only on first call, cache thereafter ─────────────────────
+let _cache = null;
+function ensureDir_NEW(dir) {
+  if (_cache) return _cache;
+  fs.mkdirSync(dir, { recursive: true });
+  _cache = dir;
+  return dir;
+}
+
+// ── Runner ───────────────────────────────────────────────────────────────────
+function bench(label, fn, iterations) {
+  // warm-up
+  fn();
+
+  const t0 = performance.now();
+  for (let i = 0; i < iterations; i++) fn();
+  const elapsed = performance.now() - t0;
+
+  console.log(
+    `${label.padEnd(36)} ${iterations} calls  |  ` +
+      `total: ${elapsed.toFixed(2).padStart(8)} ms  |  ` +
+      `per-call: ${(elapsed / iterations).toFixed(3)} ms`
+  );
+  return elapsed;
+}
+
+console.log(`\nBenchmark: ensureDir  (${ITERATIONS} iterations each)`);
+console.log(`Platform : ${process.platform}  Node ${process.version}`);
+console.log(`Test dir : ${TEST_DIR}`);
+console.log("─".repeat(80));
+
+const oldMs = bench("BEFORE (mkdirSync every call)", () => ensureDir_OLD(TEST_DIR), ITERATIONS);
+const newMs = bench("AFTER  (cached, mkdirSync once)", () => ensureDir_NEW(TEST_DIR), ITERATIONS);
+
+console.log("─".repeat(80));
+const speedup = oldMs / newMs;
+console.log(`Speedup  : ~${speedup.toFixed(0)}x faster\n`);
+console.log("Note: on Android/proot, measured mkdirSync overhead is ~0.17 ms/call.");
+console.log("With 100 ensureLogsDir() calls per typical 50-tool session (~17 ms saved)\n");
+
+// cleanup
+fs.rmSync(TEST_DIR, { recursive: true, force: true });

--- a/openclaw-plugin-mobile-ui/src/tools/workspace.ts
+++ b/openclaw-plugin-mobile-ui/src/tools/workspace.ts
@@ -26,17 +26,24 @@ export function getWorkspaceDir() {
   return "/root/.openclaw/workspace";
 }
 
+let _screenshotsDirCache: string | null = null;
+let _logsDirCache: string | null = null;
+
 export function ensureScreenshotsDir() {
+  if (_screenshotsDirCache) return _screenshotsDirCache;
   const ws = getWorkspaceDir();
   const dir = path.join(ws, "screenshots");
   fs.mkdirSync(dir, { recursive: true });
+  _screenshotsDirCache = dir;
   return dir;
 }
 
 export function ensureLogsDir() {
+  if (_logsDirCache) return _logsDirCache;
   const ws = getWorkspaceDir();
   const dir = path.join(ws, "logs");
   fs.mkdirSync(dir, { recursive: true });
+  _logsDirCache = dir;
   return dir;
 }
 


### PR DESCRIPTION
## Summary

`ensureScreenshotsDir()` and `ensureLogsDir()` in `openclaw-plugin-mobile-ui/src/tools/workspace.ts` called `fs.mkdirSync(dir, { recursive: true })` on **every single invocation** - every screenshot and every tool audit write (twice per tool call: start + end).

Since the workspace path is fixed for the process lifetime, after the first call the directory already exists and the path never changes. The `mkdirSync` is entirely redundant.

## Benchmark (1000 entries, Android/proot, Node v22)

```
BEFORE (mkdirSync every call)    1000 calls  |  total: 168.76 ms  |  per-call: 0.169 ms
AFTER  (cached, mkdirSync once)  1000 calls  |  total:   0.05 ms  |  per-call: 0.000 ms
Speedup: ~3488x faster
```

<img width="540" height="1212" alt="benchmark_android" src="https://github.com/user-attachments/assets/677d749e-b61a-447b-b323-f613159d7528" />


In a typical 50-tool session, `ensureLogsDir()` is called ~100 times (2× per tool: start + end audit). At 0.17 ms/call that is **~17 ms of avoidable latency per session**, plus additional savings from `ensureScreenshotsDir()` on every screenshot.

## Change

Two module-level cache variables added (`_screenshotsDirCache`, `_logsDirCache`). Each `ensure*Dir()` returns the cached path on all calls after the first - skipping both path computation and the `mkdirSync` syscall entirely. No change to function signatures or behaviour.

Benchmark script: `openclaw-plugin-mobile-ui/scripts/bench-dir-cache.mjs`

Closes #20 