### PR TITLE
Fix bootstrap TTY detection

### DIFF
--- a/installer/termux-lite/bootstrap.sh
+++ b/installer/termux-lite/bootstrap.sh
@@ -176,7 +176,7 @@ info "Installed command wrapper: $PREFIX/bin/clawmobile"
 
 if [ "$RUN_SETUP" = "1" ]; then
   info "Running ClawMobile setup..."
-  if [ -r /dev/tty ]; then
+  if ( : </dev/tty ) 2>/dev/null; then
     exec "$TARGET_DIR/installer/termux-lite/clawmobile" setup "$@" </dev/tty
   fi
   exec "$TARGET_DIR/installer/termux-lite/clawmobile" setup "$@"


### PR DESCRIPTION
Fixes non-interactive bootstrap runs where /dev/tty appears readable but cannot be opened, such as SSH + piped installer tests. Verified from a cleared F-Droid Termux install on the test phone: bootstrap completed, clawmobile doctor passed, and clawmobile run started the OpenClaw gateway with the mobile plugin loaded.