### PR TITLE
Fix glibc-runner installer fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ClawMobile treats the phone as the runtime.
 | Capability | Why it matters |
 | --- | --- |
 | **Local agent runtime** | The agent runs where the apps, files, notifications, and Android state already live. |
-| **Phone-native tool surface** | Use shell commands, files, network access, OCR, screenshots, UIAutomator XML, app/window state, and touch input from one OpenClaw surface. |
+| **Phone-native tool surface** | Use shell commands, files, network access, optional OCR, screenshots, UIAutomator XML, app/window state, and touch input from one OpenClaw surface. |
 | **Progressive permissions** | Start with Termux tools, then unlock Termux:API and ADB-backed UI control when the user chooses. |
 | **Learned mobile skills** | Record a task once, generate an OpenClaw skill, and improve it with more demos or execution feedback. |
 
@@ -157,7 +157,7 @@ enabled.
 
 | Stage | Enabled by | Example capabilities |
 | --- | --- | --- |
-| **Termux** | Default runtime | OpenClaw gateway, shell tools, files, network, local OCR |
+| **Termux** | Default runtime | OpenClaw gateway, shell tools, files, network, optional local OCR |
 | **Termux:API** | Termux:API app and package | Clipboard, notifications, battery, text-to-speech |
 | **ADB shell** | Authorized `adb devices` connection | Taps, swipes, typing, screenshots, UIAutomator XML, Android shell commands |
 
@@ -199,7 +199,7 @@ stable generated-skill steps, not a replacement for normal recovery.
 | OpenClaw gateway on Android | The local agent runtime running on the phone. |
 | ClawMobile workspace | Policies, capability contracts, and reusable skills. |
 | `mobile-ui` plugin | Tool bridge between OpenClaw and mobile backends. |
-| Mobile backends | Termux tools, Termux:API, ADB/Android shell, OCR, and generated skill storage. |
+| Mobile backends | Termux tools, Termux:API, ADB/Android shell, optional OCR, and generated skill storage. |
 | Android apps and device state | The real mobile environment the agent observes and acts on. |
 
 The important design choice is progressive capability. The same agent can run
@@ -209,7 +209,7 @@ authorizes them.
 ## Project Status
 
 ClawMobile is in public preview for real Android devices. The default Termux
-runtime includes the installer, OpenClaw mobile plugin, OCR support,
+runtime includes the installer, OpenClaw mobile plugin, optional OCR support,
 ADB-backed UI tools, and the trace-to-skill workflow.
 
 Generated skills are useful today, but they are still preview software. They

--- a/installer/FAQ.md
+++ b/installer/FAQ.md
@@ -172,6 +172,26 @@ clawmobile setup --quick
 If the selected network cannot reach Termux mirrors, switch networks and rerun
 setup. Re-running setup is safe; it is designed to repair an incomplete install.
 
+## OCR tools say `tesseract` is missing
+
+OCR is optional and is not installed by default. Install it only when you need
+text recognition from screenshots:
+
+```sh
+CLAWMOBILE_TERMUX_INSTALL_OCR=1 clawmobile install
+```
+
+Then verify:
+
+```sh
+tesseract --version
+tesseract --list-langs
+```
+
+If package mirrors are slow or failing, you can keep using ClawMobile without
+OCR; ADB control, screenshots, UIAutomator XML, trace recording, and generated
+skill promotion do not require the OCR package.
+
 ## What does quick setup ask for?
 
 `clawmobile setup --quick` asks for three kinds of information:
@@ -241,7 +261,7 @@ Fix:
 ## ADB is not available
 
 ClawMobile still works without ADB for Termux-side tools, files, network tasks,
-and local OCR on existing images.
+and local OCR on existing images when the optional OCR engine is installed.
 
 ADB is needed for UI control, live screenshots, UIAutomator XML, Android shell,
 fresh trace recording, and generated-skill execution against apps.

--- a/installer/INSTALL.md
+++ b/installer/INSTALL.md
@@ -1,8 +1,9 @@
 # ClawMobile Installation Guide
 
 This is the recommended public installation path for **ClawMobile**. It runs
-OpenClaw directly in Termux and includes the mobile tool runtime, OCR, optional
-ADB control, and the public-preview generated-skill workflow.
+OpenClaw directly in Termux and includes the mobile tool runtime, optional OCR,
+optional ADB control, and the public-preview
+generated-skill workflow.
 
 Most users should start here.
 
@@ -102,7 +103,7 @@ The default runtime provides:
 
 - OpenClaw running directly in Termux
 - capability-aware Termux/ADB/mobile tools
-- OCR as a base observation substrate
+- optional OCR for screenshot text recognition
 - recorder and offline trace parser
 - preview generated skill candidate, promotion, generalization, update, and
   feedback
@@ -138,10 +139,35 @@ clawmobile reset --level workspace
 
 ---
 
+## Optional OCR Setup
+
+OCR is useful when ClawMobile needs text from screenshots, but it is not needed
+for first install, gateway startup, ADB control, trace recording, or generated
+skill promotion. It is not installed by default so the normal setup stays
+smaller and less sensitive to slow package mirrors.
+
+Install OCR when you need screenshot text recognition:
+
+```sh
+CLAWMOBILE_TERMUX_INSTALL_OCR=1 clawmobile install
+```
+
+Verify it with:
+
+```sh
+tesseract --version
+tesseract --list-langs
+```
+
+If an OCR tool is called before OCR is installed, ClawMobile reports the missing
+capability and points back to this install command.
+
+---
+
 ## Optional ADB Setup
 
 ClawMobile can run without ADB for Termux-side tools, files, network tasks, and
-local OCR on existing images.
+local OCR on existing images when the optional OCR engine is installed.
 
 ADB is required for app UI control, live screenshots, UIAutomator XML, Android
 shell commands, fresh trace recording, and generated-skill execution against

--- a/installer/termux-lite/README.md
+++ b/installer/termux-lite/README.md
@@ -5,7 +5,7 @@ For normal installation, start with the
 [installation guide](../INSTALL.md).
 
 ClawMobile runs OpenClaw directly in Termux and adds Android-aware tools for
-local files, shell commands, networking, OCR, optional ADB UI control,
+local files, shell commands, networking, optional OCR, optional ADB UI control,
 demonstration recording, generated skills, and execution feedback.
 
 The `termux-lite/` directory name is historical. It is the maintained default
@@ -118,7 +118,7 @@ are available at tool-call time.
 
 | Stage | How it is reached | Available examples |
 | --- | --- | --- |
-| Termux | Default after ClawMobile starts | OpenClaw, local shell, files, network, CLI tools, local OCR on existing image files |
+| Termux | Default after ClawMobile starts | OpenClaw, local shell, files, network, CLI tools, and local OCR on existing image files when the optional OCR engine is installed |
 | Termux:API | Termux:API app plus `termux-api` package are present | toast, notifications, clipboard, battery status, text-to-speech |
 | ADB shell | `adb devices` shows a device in `device` state | taps, swipes, typing, screenshots, UIAutomator XML, `adb shell` commands |
 
@@ -182,17 +182,21 @@ when the fast path cannot finish.
 OCR is a generic observation substrate and can be useful for generated skills,
 but it is not required for trace recording or promotion.
 
-The setup path installs the local OCR engine by default. Verify it with:
+The setup path does not install the local OCR engine by default. This keeps the
+normal install smaller and avoids large optional packages on slow or unreliable
+Termux mirrors.
+
+Install OCR when you need screenshot text recognition:
+
+```sh
+CLAWMOBILE_TERMUX_INSTALL_OCR=1 clawmobile install
+```
+
+Verify it with:
 
 ```sh
 tesseract --version
 tesseract --list-langs
-```
-
-Skip OCR during setup when you need the smallest possible install:
-
-```sh
-CLAWMOBILE_TERMUX_INSTALL_OCR=0 clawmobile setup --quick
 ```
 
 English OCR is installed by the Termux `tesseract` package. For simplified

--- a/installer/termux-lite/clawmobile
+++ b/installer/termux-lite/clawmobile
@@ -12,7 +12,7 @@ Usage: clawmobile <command> [args]
 ClawMobile Termux runtime command wrapper.
 
 Commands:
-  install             Install/update Termux runtime prerequisites, OpenClaw plugin, OCR, and workspace seed.
+  install             Install/update Termux runtime prerequisites, OpenClaw plugin, optional OCR, and workspace seed.
   install-openclaw    Install/update OpenClaw for Android/Termux.
   onboard             Run OpenClaw onboarding for the Termux runtime.
   setup               Install OpenClaw + Termux runtime, then onboard.

--- a/installer/termux-lite/doctor.sh
+++ b/installer/termux-lite/doctor.sh
@@ -80,8 +80,8 @@ if command -v tesseract >/dev/null 2>&1; then
   tesseract --list-langs 2>/dev/null || true
 else
   echo "tesseract missing"
-  echo "install: ./installer/termux-lite/install.sh"
-  echo "skip during install: CLAWMOBILE_TERMUX_INSTALL_OCR=0 ./installer/termux-lite/install.sh"
+  echo "optional: install with CLAWMOBILE_TERMUX_INSTALL_OCR=1 clawmobile install"
+  echo "checkout fallback: CLAWMOBILE_TERMUX_INSTALL_OCR=1 ./installer/termux-lite/install.sh"
 fi
 
 section "plugin"

--- a/installer/termux-lite/install-openclaw.sh
+++ b/installer/termux-lite/install-openclaw.sh
@@ -62,9 +62,7 @@ install_termux_packages() {
   if [ "${CLAWMOBILE_TERMUX_UPGRADE:-0}" = "1" ]; then
     clawmobile_pkg upgrade -y
   fi
-  clawmobile_pkg install -y git curl tar xz-utils coreutils findutils gawk python make cmake clang binutils pacman
-
-  command -v pacman >/dev/null 2>&1 || die "pacman was not installed; Termux package index may be stale or mirror fallback failed."
+  clawmobile_pkg install -y git curl tar xz-utils coreutils findutils gawk python make cmake clang binutils
 
   if [ ! -e "$PREFIX/bin/ar" ] && [ -x "$PREFIX/bin/llvm-ar" ]; then
     ln -s "$PREFIX/bin/llvm-ar" "$PREFIX/bin/ar"
@@ -85,23 +83,53 @@ install_glibc_runner() {
   local pacman_conf="$PREFIX/etc/pacman.conf"
   local siglevel_patched=false
 
-  if [ -f "$PROJECT_DIR/.glibc-arch" ] && [ -x "$GLIBC_LDSO" ]; then
+  if [ -x "$GLIBC_LDSO" ]; then
     info "glibc-runner already installed."
     ensure_glibc_hosts
+    touch "$PROJECT_DIR/.glibc-arch"
     return
   fi
 
-  info "Installing glibc-runner through Termux pacman..."
-  if [ -f "$pacman_conf" ] && ! grep -q "^SigLevel = Never" "$pacman_conf"; then
+  info "Installing glibc-runner through Termux glibc apt repository..."
+  if clawmobile_pkg install -y glibc-repo && \
+     clawmobile_pkg update -y && \
+     clawmobile_pkg install -y glibc-runner; then
+    if [ -x "$GLIBC_LDSO" ]; then
+      ensure_glibc_hosts
+      touch "$PROJECT_DIR/.glibc-arch"
+      return
+    fi
+    warn "glibc-runner apt install finished, but $GLIBC_LDSO was not found."
+  else
+    warn "glibc-runner apt install failed; trying Termux pacman fallback."
+  fi
+
+  info "Installing glibc-runner through Termux pacman fallback..."
+  clawmobile_pkg install -y pacman || die "failed to install pacman for glibc-runner fallback."
+  command -v pacman >/dev/null 2>&1 || die "pacman was not installed; Termux package index may be stale or mirror fallback failed."
+
+  if [ -f "$pacman_conf" ]; then
     cp "$pacman_conf" "${pacman_conf}.bak"
-    sed -i 's/^SigLevel[[:space:]]*=.*/SigLevel = Never/' "$pacman_conf"
+    if grep -q "^SigLevel[[:space:]]*=" "$pacman_conf"; then
+      sed -i 's/^SigLevel[[:space:]]*=.*/SigLevel = Never/' "$pacman_conf"
+    else
+      printf '\nSigLevel = Never\n' >> "$pacman_conf"
+    fi
+    if grep -q "^RemoteFileSigLevel[[:space:]]*=" "$pacman_conf"; then
+      sed -i 's/^RemoteFileSigLevel[[:space:]]*=.*/RemoteFileSigLevel = Never/' "$pacman_conf"
+    else
+      printf '\nRemoteFileSigLevel = Never\n' >> "$pacman_conf"
+    fi
     siglevel_patched=true
   fi
 
   pacman-key --init 2>/dev/null || true
   pacman-key --populate 2>/dev/null || true
 
-  if ! pacman -Sy glibc-runner --noconfirm --assume-installed bash,patchelf,resolv-conf; then
+  if ! pacman -Sy glibc-runner --noconfirm \
+    --assume-installed bash \
+    --assume-installed patchelf \
+    --assume-installed resolv-conf; then
     if [ "$siglevel_patched" = true ] && [ -f "${pacman_conf}.bak" ]; then
       mv "${pacman_conf}.bak" "$pacman_conf"
     fi

--- a/installer/termux-lite/install-openclaw.sh
+++ b/installer/termux-lite/install-openclaw.sh
@@ -62,7 +62,7 @@ install_termux_packages() {
   if [ "${CLAWMOBILE_TERMUX_UPGRADE:-0}" = "1" ]; then
     clawmobile_pkg upgrade -y
   fi
-  clawmobile_pkg install -y git curl tar xz-utils coreutils findutils gawk python make cmake clang binutils
+  clawmobile_pkg install -y git curl tar xz-utils coreutils findutils gawk
 
   if [ ! -e "$PREFIX/bin/ar" ] && [ -x "$PREFIX/bin/llvm-ar" ]; then
     ln -s "$PREFIX/bin/llvm-ar" "$PREFIX/bin/ar"
@@ -332,7 +332,11 @@ install_openclaw_package() {
   export CLAWDHUB_WORKDIR="$HOME/.openclaw/workspace"
   export CPATH="$PREFIX/include/glib-2.0:$PREFIX/lib/glib-2.0/include"
 
-  python -c "import yaml" 2>/dev/null || pip install pyyaml -q || true
+  if command -v python >/dev/null 2>&1; then
+    python -c "import yaml" 2>/dev/null || {
+      command -v pip >/dev/null 2>&1 && pip install pyyaml -q || true
+    }
+  fi
 
   if npm list -g openclaw >/dev/null 2>&1 || [ -d "$PREFIX/lib/node_modules/openclaw" ]; then
     info "Existing OpenClaw install detected; reinstalling package cleanly..."

--- a/installer/termux-lite/install.sh
+++ b/installer/termux-lite/install.sh
@@ -16,12 +16,13 @@ echo "[lite] Installing ClawMobile Termux runtime prerequisites..."
 clawmobile_pkg update -y
 clawmobile_pkg install -y git curl termux-api android-tools rsync
 
-CLAWMOBILE_TERMUX_INSTALL_OCR="${CLAWMOBILE_TERMUX_INSTALL_OCR:-1}"
+CLAWMOBILE_TERMUX_INSTALL_OCR="${CLAWMOBILE_TERMUX_INSTALL_OCR:-0}"
 if [ "$CLAWMOBILE_TERMUX_INSTALL_OCR" = "1" ]; then
   echo "[lite] Installing OCR engine (tesseract)..."
   clawmobile_pkg install -y tesseract
 else
-  echo "[lite] Skipping OCR engine install (CLAWMOBILE_TERMUX_INSTALL_OCR=0)."
+  echo "[lite] Skipping optional OCR engine install."
+  echo "[lite] Install later with: CLAWMOBILE_TERMUX_INSTALL_OCR=1 clawmobile install"
 fi
 
 if ! command -v openclaw >/dev/null 2>&1 && [ "${CLAWMOBILE_TERMUX_INSTALL_OPENCLAW:-0}" = "1" ]; then

--- a/installer/termux-lite/install.sh
+++ b/installer/termux-lite/install.sh
@@ -25,7 +25,14 @@ else
   echo "[lite] Install later with: CLAWMOBILE_TERMUX_INSTALL_OCR=1 clawmobile install"
 fi
 
-if ! command -v openclaw >/dev/null 2>&1 && [ "${CLAWMOBILE_TERMUX_INSTALL_OPENCLAW:-0}" = "1" ]; then
+needs_openclaw_install=0
+if ! command -v openclaw >/dev/null 2>&1; then
+  needs_openclaw_install=1
+elif ! command -v npm >/dev/null 2>&1; then
+  needs_openclaw_install=1
+fi
+
+if [ "$needs_openclaw_install" = "1" ] && [ "${CLAWMOBILE_TERMUX_INSTALL_OPENCLAW:-0}" = "1" ]; then
   "$SCRIPT_DIR/install-openclaw.sh"
   clawmobile_lite_env
 fi

--- a/installer/termux-lite/run.sh
+++ b/installer/termux-lite/run.sh
@@ -21,6 +21,30 @@ clawmobile_build_plugin_lite "$REPO_ROOT"
 clawmobile_install_plugin "$PLUGIN_DIR"
 clawmobile_sync_workspace_seed "$REPO_ROOT"
 
+ensure_gateway_config() {
+  local current=""
+
+  current="$(openclaw config get gateway.mode 2>/dev/null || true)"
+  if [ "$current" != "local" ]; then
+    echo "[lite] Setting OpenClaw gateway.mode=local"
+    openclaw config set gateway.mode local </dev/null >/dev/null
+  fi
+
+  current="$(openclaw config get gateway.port 2>/dev/null || true)"
+  if [ "$current" != "$GATEWAY_PORT" ]; then
+    echo "[lite] Setting OpenClaw gateway.port=$GATEWAY_PORT"
+    openclaw config set gateway.port "$GATEWAY_PORT" </dev/null >/dev/null
+  fi
+
+  current="$(openclaw config get gateway.bind 2>/dev/null || true)"
+  if [ "$current" != "$GATEWAY_BIND" ]; then
+    echo "[lite] Setting OpenClaw gateway.bind=$GATEWAY_BIND"
+    openclaw config set gateway.bind "$GATEWAY_BIND" </dev/null >/dev/null
+  fi
+}
+
+ensure_gateway_config
+
 if [ "${CLAWMOBILE_TERMUX_REFRESH_DEFAULTS_ON_RUN:-0}" = "1" ]; then
   echo "[lite] Refreshing OpenClaw Termux runtime defaults before gateway start..."
   openclaw config set tools.profile full </dev/null

--- a/openclaw-plugin-mobile-ui/src/tools/android.ts
+++ b/openclaw-plugin-mobile-ui/src/tools/android.ts
@@ -346,7 +346,7 @@ function normalizeTextMatchPickStrategy(value?: string | null): TextMatchPickStr
 async function requireOcrInputCapabilities(input?: { path?: string }) {
   const ocrUnavailable = await requireRuntimeCapability(
     "ocr",
-    "OCR requires the local tesseract binary. Install it in Termux with `pkg install tesseract`."
+    "OCR requires the optional local tesseract binary. Install it with `CLAWMOBILE_TERMUX_INSTALL_OCR=1 clawmobile install`."
   );
   if (ocrUnavailable) return ocrUnavailable;
 


### PR DESCRIPTION
This PR updates the Termux OpenClaw bootstrap so glibc-runner installation is more robust.\n\nChanges:\n- Accept an already-installed glibc-runner when the glibc dynamic linker exists.\n- Prefer the current Termux apt path via glibc-repo before falling back to pacman.\n- Install pacman only for the fallback path and make the fallback less sensitive to missing signature files.