### PR TITLE
Fix token usage cost aggregation

### DIFF
--- a/openclaw-plugin-mobile-ui/package.json
+++ b/openclaw-plugin-mobile-ui/package.json
@@ -13,6 +13,7 @@
     "build": "node ./node_modules/typescript/bin/tsc -p tsconfig.json && node scripts/prepare-lite.mjs",
     "dev": "node ./node_modules/typescript/bin/tsc -p tsconfig.json -w",
     "companion:server": "node dist/companion/server.js",
+    "test:companion-runs": "node scripts/test-companion-runs.cjs",
     "test:companion-sharing": "node scripts/test-companion-sharing.cjs",
     "test:trace-induction": "node scripts/test-trace-induction.cjs"
   },

--- a/openclaw-plugin-mobile-ui/scripts/test-companion-runs.cjs
+++ b/openclaw-plugin-mobile-ui/scripts/test-companion-runs.cjs
@@ -1,0 +1,115 @@
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawmobile-companion-runs-"));
+process.env.OPENCLAW_STATE_DIR = path.join(root, "openclaw-state");
+process.env.CLAWMOBILE_AGENT_ID = "main";
+
+const sessionsDir = path.join(process.env.OPENCLAW_STATE_DIR, "agents", "main", "sessions");
+fs.mkdirSync(sessionsDir, { recursive: true });
+
+const sessionId = "session-token-usage";
+const runId = "run_123_cost";
+fs.writeFileSync(
+  path.join(sessionsDir, "sessions.json"),
+  JSON.stringify({
+    sessions: [
+      {
+        sessionId,
+        key: "agent:main:companion-run-123-cost",
+        label: "ClawMobile Companion",
+        status: "completed",
+        startedAt: 1000,
+        endedAt: 2000,
+      },
+    ],
+  }, null, 2),
+);
+
+const trajectoryEvents = [
+  {
+    type: "prompt.submitted",
+    runId,
+    ts: "2026-06-24T00:00:00.000Z",
+    data: { prompt: "Measure token usage." },
+  },
+  {
+    type: "model.completed",
+    runId,
+    ts: "2026-06-24T00:00:01.000Z",
+    data: {
+      assistantTexts: ["First model response."],
+      usage: {
+        input_tokens: 1000,
+        output_tokens: 200,
+        prompt_tokens_details: { cached_tokens: 800 },
+        estimated_cost_usd: 0.0123,
+      },
+    },
+  },
+  {
+    type: "model.completed",
+    runId,
+    ts: "2026-06-24T00:00:02.000Z",
+    data: {
+      assistantTexts: ["Second model response."],
+      usage: {
+        inputTokens: 500,
+        outputTokens: 50,
+        costUsd: 0.004,
+      },
+    },
+  },
+  {
+    type: "model.completed",
+    runId,
+    ts: "2026-06-24T00:00:03.000Z",
+    data: {
+      assistantTexts: ["Final model response."],
+      usage: {
+        input_tokens: 30,
+        output_tokens_details: { reasoning_tokens: 7 },
+        estimatedCostUsd: 0.001,
+      },
+    },
+  },
+  {
+    type: "session.ended",
+    runId,
+    ts: "2026-06-24T00:00:04.000Z",
+    data: { status: "success" },
+  },
+];
+fs.writeFileSync(
+  path.join(sessionsDir, `${sessionId}.trajectory.jsonl`),
+  trajectoryEvents.map((event) => JSON.stringify(event)).join("\n"),
+);
+
+const { getRunStatus } = require("../dist/companion/runs.js");
+
+(async () => {
+  const status = await getRunStatus(runId);
+  assert.strictEqual(status.success, true);
+  assert.strictEqual(status.state, "done");
+  assert.strictEqual(status.result, "Final model response.");
+  assert.ok(status.tokenUsage);
+  assert.ok(Math.abs(status.tokenUsage.estimatedCostUsd - 0.0173) < 0.0000001);
+  assert.deepStrictEqual({
+    ...status.tokenUsage,
+    estimatedCostUsd: undefined,
+  }, {
+    inputTokens: 1530,
+    outputTokens: 250,
+    totalTokens: 1787,
+    cachedTokens: 800,
+    reasoningTokens: 7,
+    estimatedCost: "$0.02",
+    estimatedCostUsd: undefined,
+  });
+  console.log(`companion runs test passed: ${root}`);
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/openclaw-plugin-mobile-ui/src/companion/runs.ts
+++ b/openclaw-plugin-mobile-ui/src/companion/runs.ts
@@ -904,34 +904,41 @@ function tokenUsageFromRaw(usage: any): CompanionRunTokenUsage | undefined {
     usage.cached_tokens,
     usage.cacheRead,
     usage.cache_read,
+    usage.input_tokens_details?.cached_tokens,
+    usage.prompt_tokens_details?.cached_tokens,
   );
   const reasoningTokens = firstNumber(
     usage.reasoningTokens,
     usage.reasoning_tokens,
+    usage.output_tokens_details?.reasoning_tokens,
+    usage.completion_tokens_details?.reasoning_tokens,
   );
   const totalTokens = firstNumber(
     usage.totalTokens,
     usage.total_tokens,
     usage.total,
-  ) || sumDefined(inputTokens, outputTokens, cachedTokens, reasoningTokens);
-  const estimatedCost = formatEstimatedCost(
-    firstNumber(
-      usage.estimatedCost,
-      usage.estimated_cost,
-      usage.costUsd,
-      usage.cost_usd,
-      usage.cost?.total,
-      usage.cost,
-    ),
   );
+  const fallbackTotalTokens = totalTokens ?? fallbackTotalTokenCount(inputTokens, outputTokens, reasoningTokens);
+  const estimatedCostUsd = firstNumber(
+    usage.estimatedCostUsd,
+    usage.estimated_cost_usd,
+    usage.estimatedCost,
+    usage.estimated_cost,
+    usage.costUsd,
+    usage.cost_usd,
+    usage.cost?.total,
+    usage.cost,
+  );
+  const estimatedCost = formatEstimatedCost(estimatedCostUsd);
 
   if (
     inputTokens === undefined &&
     outputTokens === undefined &&
     cachedTokens === undefined &&
     reasoningTokens === undefined &&
-    totalTokens === undefined &&
-    estimatedCost === undefined
+    fallbackTotalTokens === undefined &&
+    estimatedCost === undefined &&
+    estimatedCostUsd === undefined
   ) {
     return undefined;
   }
@@ -939,10 +946,11 @@ function tokenUsageFromRaw(usage: any): CompanionRunTokenUsage | undefined {
   return {
     inputTokens,
     outputTokens,
-    totalTokens,
+    totalTokens: fallbackTotalTokens,
     cachedTokens,
     reasoningTokens,
     estimatedCost,
+    estimatedCostUsd,
   };
 }
 
@@ -958,7 +966,8 @@ function accumulateTokenUsage(
     totalTokens: sumDefined(left.totalTokens, right.totalTokens),
     cachedTokens: sumDefined(left.cachedTokens, right.cachedTokens),
     reasoningTokens: sumDefined(left.reasoningTokens, right.reasoningTokens),
-    estimatedCost: right.estimatedCost || left.estimatedCost,
+    estimatedCostUsd: sumDefined(left.estimatedCostUsd, right.estimatedCostUsd),
+    estimatedCost: formatEstimatedCost(sumDefined(left.estimatedCostUsd, right.estimatedCostUsd)) || right.estimatedCost || left.estimatedCost,
   });
 }
 
@@ -973,6 +982,7 @@ function mergeTokenUsage(
       totalTokens: usage.totalTokens ?? current.totalTokens,
       cachedTokens: usage.cachedTokens ?? current.cachedTokens,
       reasoningTokens: usage.reasoningTokens ?? current.reasoningTokens,
+      estimatedCostUsd: usage.estimatedCostUsd ?? current.estimatedCostUsd,
       estimatedCost: usage.estimatedCost ?? current.estimatedCost,
     };
   }, {});
@@ -986,7 +996,8 @@ function compactTokenUsage(usage: CompanionRunTokenUsage): CompanionRunTokenUsag
     usage.totalTokens === undefined &&
     usage.cachedTokens === undefined &&
     usage.reasoningTokens === undefined &&
-    usage.estimatedCost === undefined
+    usage.estimatedCost === undefined &&
+    usage.estimatedCostUsd === undefined
   ) {
     return undefined;
   }
@@ -1005,6 +1016,17 @@ function sumDefined(...values: Array<number | undefined>): number | undefined {
   const numbers = values.filter((value): value is number => value !== undefined);
   if (numbers.length === 0) return undefined;
   return numbers.reduce((sum, value) => sum + value, 0);
+}
+
+function fallbackTotalTokenCount(
+  inputTokens: number | undefined,
+  outputTokens: number | undefined,
+  reasoningTokens: number | undefined,
+): number | undefined {
+  if (inputTokens !== undefined || outputTokens !== undefined) {
+    return sumDefined(inputTokens, outputTokens ?? reasoningTokens);
+  }
+  return reasoningTokens;
 }
 
 function formatEstimatedCost(value: number | undefined): string | undefined {

--- a/openclaw-plugin-mobile-ui/src/companion/types.ts
+++ b/openclaw-plugin-mobile-ui/src/companion/types.ts
@@ -110,6 +110,7 @@ export type CompanionRunTokenUsage = {
   cachedTokens?: number;
   reasoningTokens?: number;
   estimatedCost?: string;
+  estimatedCostUsd?: number;
 };
 
 export type CompanionRunProgress = {


### PR DESCRIPTION
## Summary
- keep cached input tokens out of fallback total-token calculations
- aggregate numeric estimated cost across multi-call runs
- expose estimatedCostUsd while preserving the formatted estimatedCost field

## Verification
- npm run build