### PR TITLE
Expose companion runtime protocol v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://clawmobile.ae/">Website</a> ·
   <a href="https://arxiv.org/abs/2602.22942">Paper</a> ·
   <a href="docs/android-companion-app.md">Android App</a> ·
+  <a href="docs/runtime-protocol-v1.md">Runtime Protocol</a> ·
   <a href="installer/INSTALL.md">Install</a> ·
   <a href="installer/FAQ.md">FAQ</a> ·
   <a href="SECURITY.md">Security</a> ·

--- a/docs/runtime-protocol-v1.md
+++ b/docs/runtime-protocol-v1.md
@@ -261,7 +261,7 @@ metadata so clients and agents can decide what is callable:
     {
       "id": "terminal.command",
       "method": "POST",
-      "path": "/terminal/command",
+      "path": "terminal/command",
       "label": "Run Terminal Command",
       "risk": "high",
       "requiresApproval": true,
@@ -287,7 +287,9 @@ metadata so clients and agents can decide what is callable:
 ```
 
 `routes[].path` is relative to `basePath`. In the example above, the full route
-is `/v1/extensions/android/terminal/command`.
+is `/v1/extensions/android/terminal/command`. Route `status` uses the same
+values as feature status, such as `available`, `local_only`, `setup_required`,
+or `unavailable`.
 
 `inputSchema` and `outputSchema` are recommended, but extension routes may
 initially advertise only `id`, `method`, `path`, `status`, `risk`, and

--- a/docs/runtime-protocol-v1.md
+++ b/docs/runtime-protocol-v1.md
@@ -1,0 +1,894 @@
+# ClawMobile Runtime Protocol v1
+
+**Status:** draft shared contract  
+**Audience:** Android app, iOS app, Termux/OpenClaw companion server, future cloud or desktop runtimes  
+**Last updated:** 2026-06-29
+
+## Purpose
+
+ClawMobile clients should be able to talk to different runtime backends through
+one stable protocol. A backend may be:
+
+- Android Termux + OpenClaw;
+- an iOS app-local runtime;
+- another phone on the LAN or Tailscale;
+- a desktop/server/cloud runtime.
+
+The protocol does not require every backend to support the same tools. Instead,
+every backend must expose a small common task API and a capability description
+that tells clients what optional features are available.
+
+## Stability Rules
+
+This document defines the v1 wire contract. Additive changes are allowed:
+
+- servers may add optional fields to existing objects;
+- clients must ignore unknown fields and preserve them for diagnostics where
+  practical;
+- clients should not assume every optional endpoint or feature is present;
+- required fields should not be renamed or removed inside `/v1`.
+
+Breaking changes should use a new namespace such as `/v2`.
+
+## Compatibility Model
+
+`/v1` is the cross-platform runtime protocol namespace.
+
+Legacy Android companion endpoints such as `/intent`, `/runs`, `/skills`, and
+`/runtime/log` are historical implementation details. They are not part of the
+v1 contract, and v1 clients must call `/v1` endpoints directly.
+
+During migration, implementations may use the old endpoint behavior internally,
+but exposed routes should use the v1 namespace. Clients should be liberal
+readers:
+
+- accept `camelCase` and `snake_case`;
+- accept ISO-8601 timestamps, epoch seconds, and epoch milliseconds;
+- normalize run states such as `queued`, `pending`, `running`, `done`,
+  `completed`, `success`, `failed`, `cancelled`, and `waiting_for_approval`;
+- preserve unknown fields for debugging where the platform makes that easy.
+
+## Transport
+
+The baseline transport is HTTP JSON.
+
+Streaming is optional in v1:
+
+```text
+WS /v1/events
+```
+
+If WebSocket events are not supported, clients must be able to poll run status.
+
+Clients should send these headers when possible:
+
+```text
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer <pairing-token>
+X-ClawMobile-Client: android
+X-ClawMobile-Request-Id: req_<client-generated-id>
+```
+
+`Authorization` may be omitted for an explicitly local, unpaired runtime. Remote
+LAN, Tailscale, desktop, and cloud runtimes should require it for every endpoint
+except unauthenticated pairing/bootstrap routes.
+
+Suggested `X-ClawMobile-Client` values are `android`, `ios`, `desktop`, and
+`cloud`. Clients may append version detail in `User-Agent`.
+
+## Error Model
+
+Non-2xx HTTP responses should use a common JSON shape:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "auth_required",
+    "message": "Pairing token is missing or invalid.",
+    "retryable": false,
+    "details": {}
+  },
+  "requestId": "req_abc123"
+}
+```
+
+Recommended HTTP status mapping:
+
+| Status | Meaning |
+| --- | --- |
+| `400` | Invalid JSON, invalid query parameter, or malformed request. |
+| `401` | Missing or invalid authentication. |
+| `403` | Authenticated but not permitted by pairing, policy, or capability scope. |
+| `404` | Run, session, skill, artifact, approval, or extension route not found. |
+| `409` | State conflict, for example approving an already resolved approval. |
+| `413` | Attachment or request payload too large. |
+| `422` | Valid JSON but semantically invalid inputs. |
+| `429` | Rate limited or runtime concurrency limit reached. |
+| `500` | Backend bug or unexpected runtime failure. |
+| `503` | Runtime dependency unavailable, such as Termux/OpenClaw not running. |
+
+Common error codes should be stable strings such as:
+
+```text
+bad_request
+auth_required
+forbidden
+not_found
+state_conflict
+payload_too_large
+validation_failed
+rate_limited
+runtime_unavailable
+tool_unavailable
+approval_required
+internal_error
+```
+
+Successful command responses may continue to use the lightweight
+`{ "success": true, "message": "..." }` shape.
+
+## Authentication and Pairing
+
+Remote execution must be explicitly paired. A backend should maintain a trust
+record per client device:
+
+```json
+{
+  "clientId": "ios-device-abc",
+  "clientName": "Alice iPhone",
+  "platform": "ios",
+  "trustStatus": "paired",
+  "scopes": ["runs:create", "runs:read", "skills:read"],
+  "createdAt": "2026-06-29T10:00:00Z",
+  "lastSeenAt": "2026-06-29T10:24:03Z"
+}
+```
+
+Trust status values:
+
+```text
+unpaired | paired | revoked
+```
+
+Pairing endpoints are intentionally outside the required core surface because
+local-only and cloud runtimes may pair differently. Implementations may expose
+pairing routes under an extension namespace, for example:
+
+```text
+/v1/extensions/pairing/challenge
+/v1/extensions/pairing/confirm
+/v1/extensions/pairing/revoke
+```
+
+Before a client is paired, a remote backend should make pairing discoverable in
+one of two ways:
+
+- allow unauthenticated `GET /v1/capabilities` that returns only safe bootstrap
+  fields and the pairing extension routes;
+- or expose fixed unauthenticated pairing routes and document them out of band,
+  for example in a QR code, setup screen, or local network discovery response.
+
+Unauthenticated capabilities must not advertise runnable tools, existing runs,
+sessions, logs, artifacts, or private device metadata.
+
+Capabilities may be scoped by the current token. A backend should only advertise
+tools, extension routes, and feature states that the authenticated client can use.
+High-risk actions must still use approval checks even after pairing.
+
+## Required Endpoints
+
+Every v1 backend should implement:
+
+```text
+GET  /v1/health
+GET  /v1/capabilities
+POST /v1/runs
+GET  /v1/runs?limit=100
+GET  /v1/runs/{runId}
+```
+
+This is enough for a client to check readiness, understand backend features,
+start a task, show history, and poll task completion.
+
+## Recommended Endpoints
+
+Backends should implement these when the feature is meaningful:
+
+```text
+POST   /v1/runs/{runId}/cancel
+GET    /v1/sessions
+POST   /v1/sessions
+POST   /v1/sessions/{sessionId}/archive
+DELETE /v1/sessions/{sessionId}
+
+POST   /v1/attachments
+GET    /v1/attachments/{attachmentId}/content
+GET    /v1/artifacts/{artifactId}
+
+GET    /v1/runtime/log?maxBytes=64000
+POST   /v1/runtime/start
+POST   /v1/runtime/restart
+POST   /v1/runtime/stop
+
+GET    /v1/skills
+POST   /v1/skills/route
+GET    /v1/skills/{skillId}
+POST   /v1/skills/{skillId}/preview
+POST   /v1/skills/{skillId}/run
+GET    /v1/skills/{skillId}/runs
+GET    /v1/skill-runs/{runId}
+
+GET    /v1/approvals?runId={runId}
+GET    /v1/approvals/{approvalId}
+POST   /v1/approvals/{approvalId}
+```
+
+## Extensions
+
+Platform-specific features should not be required by the core protocol. They can
+be exposed as extensions and advertised through `/v1/capabilities`.
+
+Suggested namespace:
+
+```text
+/v1/extensions/{namespace}/...
+```
+
+Examples:
+
+```text
+/v1/extensions/android/terminal/command
+/v1/extensions/nostr/contacts
+/v1/extensions/nostr/inbox
+/v1/extensions/skill-sharing/imports
+```
+
+Android-specific routes should be exposed through extension namespaces instead
+of top-level legacy paths such as `/terminal/*`, `/nostr/*`, `/agent/*`,
+`/skill-imports/*`, or `/skills/{skillId}/share`.
+
+Extensions should be discoverable. Each advertised extension may include route
+metadata so clients and agents can decide what is callable:
+
+```json
+{
+  "namespace": "android",
+  "basePath": "/v1/extensions/android",
+  "status": "available",
+  "routes": [
+    {
+      "id": "terminal.command",
+      "method": "POST",
+      "path": "/terminal/command",
+      "label": "Run Terminal Command",
+      "risk": "high",
+      "requiresApproval": true,
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "command": { "type": "string" },
+          "timeoutMs": { "type": "integer" }
+        },
+        "required": ["command"]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "exitCode": { "type": "integer" },
+          "stdout": { "type": "string" },
+          "stderr": { "type": "string" }
+        }
+      }
+    }
+  ]
+}
+```
+
+`routes[].path` is relative to `basePath`. In the example above, the full route
+is `/v1/extensions/android/terminal/command`.
+
+`inputSchema` and `outputSchema` are recommended, but extension routes may
+initially advertise only `id`, `method`, `path`, `status`, `risk`, and
+`requiresApproval`. Core clients may ignore unknown extensions. Agent runtimes
+should treat extension route metadata as capability discovery, not as permission
+to bypass approval.
+
+## Health
+
+```text
+GET /v1/health
+```
+
+Response:
+
+```json
+{
+  "status": "connected",
+  "message": "Runtime is ready.",
+  "version": "0.4.1",
+  "stage": "ready",
+  "checks": [
+    {
+      "id": "runtime",
+      "label": "Runtime",
+      "state": "online",
+      "detail": "OpenClaw gateway is reachable."
+    }
+  ]
+}
+```
+
+`status` values:
+
+```text
+connected | disconnected | unknown
+```
+
+`checks[].state` values:
+
+```text
+online | degraded | offline | unknown
+```
+
+## Capabilities
+
+```text
+GET /v1/capabilities
+```
+
+This endpoint tells the frontend what a backend can do. It is the main mechanism
+for making Android, iOS, cloud, and desktop runtimes compatible without forcing
+them to expose identical tools.
+
+Response:
+
+```json
+{
+  "platform": "android",
+  "runtime": "termux-openclaw",
+  "version": "0.4.1",
+  "features": {
+    "tasks": "available",
+    "sessions": "available",
+    "skills": "available",
+    "attachments": "available",
+    "artifacts": "planned",
+    "approvals": "planned",
+    "events": "unavailable",
+    "runtimeLifecycle": "available",
+    "runtimeLog": "available",
+    "notifications": "frontend",
+    "adb": "available",
+    "ocr": "setup_required",
+    "terminal": "local_only",
+    "social": "available",
+    "appIntents": "unavailable"
+  },
+  "tools": [
+    {
+      "id": "android_health",
+      "label": "Android Health",
+      "description": "Read Android runtime health and setup status.",
+      "status": "available",
+      "risk": "low",
+      "requiresApproval": false,
+      "extension": "android",
+      "permissions": [],
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "message": { "type": "string" }
+        }
+      },
+      "availabilityReason": null
+    }
+  ],
+  "extensions": [
+    {
+      "namespace": "nostr",
+      "basePath": "/v1/extensions/nostr",
+      "status": "available",
+      "routes": []
+    }
+  ]
+}
+```
+
+Feature status values:
+
+```text
+available | setup_required | unavailable | local_only | frontend | planned
+```
+
+`frontend` means the capability is handled by the client app rather than the
+backend. For example, mobile notifications may be posted by the Android/iOS app
+after polling a run to completion.
+
+Tool risk values:
+
+```text
+low | medium | high | critical
+```
+
+Tool status values:
+
+```text
+available | setup_required | unavailable | permission_required | planned
+```
+
+`requiresApproval` means the backend must pause the run and create an approval
+request before executing the tool or extension route. Clients should still show
+risk and permission information before starting a run when it is known.
+
+## Create Run
+
+```text
+POST /v1/runs
+```
+
+Request:
+
+```json
+{
+  "clientRunId": "client-run-abc123",
+  "instruction": "Summarize the shared web page and list any action items.",
+  "displayText": "Summarize this link\nhttps://example.com",
+  "sessionId": "share-2026-06-29",
+  "attachments": [],
+  "source": {
+    "surface": "share",
+    "actionId": "webpage.summarize",
+    "contentType": "text/uri-list"
+  },
+  "metadata": {
+    "client": "android"
+  }
+}
+```
+
+Fields:
+
+- `clientRunId`: optional client-generated idempotency key. If the same client
+  retries the same request, the backend should return the original accepted run
+  when practical. The idempotency scope is `clientId + clientRunId`, where
+  `clientId` is the paired client identity or another stable authenticated
+  client identifier. If the same client repeats the same `clientRunId` with the
+  same request body, the backend should return the original run. If the body is
+  materially different, the backend should return `409 state_conflict`.
+- `instruction`: the complete instruction sent to the agent. This may include
+  hidden context or prompt scaffolding.
+- `displayText`: the user-facing text that clients should show in task/chat UI.
+- `sessionId`: client-selected conversation/session id.
+- `attachments`: attachment references.
+- `source`: where this run came from, such as `task`, `share`, `skill`,
+  `social`, or `automation`.
+- `metadata`: optional backend-agnostic metadata.
+
+Legacy compatibility:
+
+```json
+{
+  "text": "Do something",
+  "sessionId": "default",
+  "attachments": []
+}
+```
+
+If `instruction` is missing, the server should treat `text` as the instruction.
+If `displayText` is missing, the server should use `userText`, then `text`, then
+`instruction` as the visible user text.
+
+Response:
+
+```json
+{
+  "success": true,
+  "message": "Task accepted.",
+  "runId": "run_abc123",
+  "clientRunId": "client-run-abc123",
+  "sessionId": "share-2026-06-29",
+  "state": "running",
+  "userText": "Summarize this link\nhttps://example.com",
+  "attachments": [],
+  "requestId": "req_abc123"
+}
+```
+
+## Run Status
+
+```text
+GET /v1/runs/{runId}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "runId": "run_abc123",
+  "sessionId": "share-2026-06-29",
+  "state": "done",
+  "message": "Task complete.",
+  "result": "The page explains...",
+  "pendingApprovals": [],
+  "progress": {
+    "text": "Finished",
+    "detail": "Final answer is ready.",
+    "updatedAt": "2026-06-29T10:24:03Z",
+    "events": [
+      {
+        "type": "tool_call",
+        "label": "Opened browser",
+        "detail": "Loaded https://example.com",
+        "at": "2026-06-29T10:23:55Z"
+      }
+    ]
+  },
+  "prompt": "Summarize the shared web page and list any action items.",
+  "userText": "Summarize this link\nhttps://example.com",
+  "attachments": [],
+  "startedAt": "2026-06-29T10:23:40Z",
+  "updatedAt": "2026-06-29T10:24:03Z",
+  "runtimeMs": 23000,
+  "tokenUsage": {
+    "inputTokens": 12000,
+    "outputTokens": 900,
+    "totalTokens": 12900,
+    "cachedTokens": 8000,
+    "reasoningTokens": 300,
+    "estimatedCostUsd": 0.0123,
+    "estimatedCost": "$0.0123"
+  }
+}
+```
+
+Run states:
+
+```text
+queued | running | waiting_for_approval | done | failed | cancelled | unknown
+```
+
+Clients should treat `done`, `failed`, and `cancelled` as terminal.
+
+When a run is waiting for user approval, the run status should include compact
+approval cards so clients know what to render without an additional discovery
+request:
+
+```json
+{
+  "state": "waiting_for_approval",
+  "pendingApprovals": [
+    {
+      "approvalId": "approval_abc123",
+      "title": "Run terminal command?",
+      "risk": "high",
+      "kind": "tool_call"
+    }
+  ]
+}
+```
+
+Recommended state transitions:
+
+```text
+queued -> running
+running -> waiting_for_approval
+waiting_for_approval -> running
+running -> done
+running -> failed
+queued|running|waiting_for_approval -> cancelled
+```
+
+`POST /v1/runs/{runId}/cancel` should be idempotent. Cancelling a terminal run
+should return the current terminal run status rather than creating a new failure.
+Backends may reject cancellation when the underlying platform cannot stop the
+operation, but they should report the resulting state clearly.
+
+## List Runs
+
+```text
+GET /v1/runs?limit=100
+```
+
+Response:
+
+```json
+{
+  "runs": [],
+  "nextCursor": null
+}
+```
+
+Wrapped list responses are preferred over bare arrays so future pagination and
+warnings can be added without changing the shape.
+
+## Attachments
+
+```text
+POST /v1/attachments
+```
+
+This endpoint is optional but recommended for remote image/file shares.
+
+Clients may upload files first and then reference the returned attachment in
+`POST /v1/runs`.
+
+Backends should support `multipart/form-data` for binary uploads. JSON-only
+backends may support base64 payloads for small files, but clients should prefer
+multipart when it is available. Backends should document `maxBytes` in
+`/v1/capabilities` when they enforce a limit.
+
+Attachment object:
+
+```json
+{
+  "id": "client-attachment-id",
+  "type": "image",
+  "mimeType": "image/png",
+  "displayName": "screenshot.png",
+  "sizeBytes": 123456,
+  "serverId": "att_abc123",
+  "serverPath": "/home/user/.clawmobile/companion-attachments/att_abc123.png",
+  "downloadUrl": "/v1/attachments/att_abc123/content",
+  "expiresAt": null
+}
+```
+
+The backend should not expose local filesystem paths to remote clients unless the
+path is meaningful and safe for that client. Prefer `serverId` and
+`downloadUrl` for cross-device clients. Treat `serverPath` as a legacy/local
+backend hint, not as the portable way to read attachment bytes.
+
+## Runtime Lifecycle and Log
+
+```text
+POST /v1/runtime/start
+POST /v1/runtime/restart
+POST /v1/runtime/stop
+GET  /v1/runtime/log?maxBytes=64000
+```
+
+Lifecycle endpoints are optional. An app-local iOS runtime may report them as
+`unavailable` or implement them as no-ops, while an Android Termux backend can
+use them to start or restart the OpenClaw gateway.
+
+Command response:
+
+```json
+{
+  "success": true,
+  "message": "Runtime start command was sent."
+}
+```
+
+Log response:
+
+```json
+{
+  "success": true,
+  "message": "Runtime log loaded.",
+  "text": "...",
+  "path": "/tmp/openclaw-gateway.log",
+  "exists": true,
+  "size": 2048,
+  "truncated": false,
+  "updatedAt": "2026-06-29T10:24:03Z"
+}
+```
+
+## Skills
+
+Skills are optional, but backends that expose a skills library should use these
+routes:
+
+```text
+GET  /v1/skills
+POST /v1/skills/route
+GET  /v1/skills/{skillId}
+POST /v1/skills/{skillId}/preview
+POST /v1/skills/{skillId}/run
+GET  /v1/skills/{skillId}/runs
+GET  /v1/skill-runs/{runId}
+```
+
+The first version may reuse the current Android skill JSON shape. Required
+client-visible fields for a skill summary:
+
+```json
+{
+  "id": "skill_id",
+  "name": "Skill Name",
+  "description": "What this skill does.",
+  "status": "trusted",
+  "risk": "low",
+  "source": "generated",
+  "scope": "app",
+  "tags": [],
+  "primaryUse": "When to use it.",
+  "requiresConfirmation": false
+}
+```
+
+## Approvals
+
+Approvals are optional in the HTTP surface, but they are required for backends
+that expose high-risk tools or extension routes.
+
+Approval request object:
+
+```json
+{
+  "approvalId": "approval_abc123",
+  "runId": "run_abc123",
+  "sessionId": "share-2026-06-29",
+  "status": "pending",
+  "kind": "tool_call",
+  "title": "Run terminal command?",
+  "detail": "The Android runtime wants to execute a shell command.",
+  "risk": "high",
+  "toolId": "android_terminal_command",
+  "proposedAction": {
+    "command": "ls -la",
+    "timeoutMs": 10000
+  },
+  "createdAt": "2026-06-29T10:23:55Z"
+}
+```
+
+Approval statuses:
+
+```text
+pending | approved | denied | expired | cancelled
+```
+
+Resolve an approval:
+
+```text
+POST /v1/approvals/{approvalId}
+```
+
+Request:
+
+```json
+{
+  "decision": "approved",
+  "message": "Allowed for this run only."
+}
+```
+
+Decision values:
+
+```text
+approved | denied
+```
+
+After an approval is resolved, the run should either resume or move to `failed`
+or `cancelled` with a clear message. Resolving an already resolved approval
+should return `409 state_conflict` or the current approval object.
+
+List or fetch approvals:
+
+```text
+GET /v1/approvals?runId=run_abc123
+GET /v1/approvals/approval_abc123
+```
+
+Wrapped list response:
+
+```json
+{
+  "approvals": [],
+  "nextCursor": null
+}
+```
+
+## Events
+
+```text
+WS /v1/events
+```
+
+Optional event payload:
+
+```json
+{
+  "eventId": "evt_abc123",
+  "sequence": 42,
+  "type": "run.updated",
+  "runId": "run_abc123",
+  "sessionId": "share-2026-06-29",
+  "state": "running",
+  "message": "Reading screen...",
+  "at": "2026-06-29T10:23:55Z",
+  "data": {}
+}
+```
+
+Event types should be extensible. Suggested core event types:
+
+```text
+run.created
+run.updated
+run.completed
+run.failed
+tool.called
+tool.output
+approval.requested
+approval.resolved
+token_usage.updated
+log.line
+```
+
+`eventId` should be globally unique within the backend. `sequence` should be
+monotonic per backend or per run so clients can de-duplicate events. WebSocket
+clients should be able to reconnect with a cursor when the backend supports it:
+
+```text
+WS /v1/events?sinceSequence=42
+```
+
+If the backend cannot replay events, it should advertise `events: "available"`
+but omit replay support in capabilities. Clients must still be able to poll
+`GET /v1/runs/{runId}` to recover the latest state.
+
+## Security
+
+Remote execution must be explicit and auditable:
+
+- clients should show the active runtime target before starting a task;
+- remote endpoints should use a pairing token or another explicit trust flow;
+- high-risk tools should require approval;
+- logs and run history should make backend actions inspectable;
+- extension capabilities should not imply permission to run high-risk actions.
+
+LAN or Tailscale reachability does not replace ClawMobile pairing, capability
+policy, or approval checks.
+
+## Android Historical Mapping
+
+This table documents how the original Android companion routes map to v1. It is
+for migration review only; v1 servers do not need to keep these legacy routes
+available.
+
+| Legacy route | v1 route | Notes |
+| --- | --- | --- |
+| `GET /health` | `GET /v1/health` | Same response shape is acceptable initially. |
+| `POST /intent` | `POST /v1/runs` | Accept `instruction/displayText`; fallback to `text`. |
+| `GET /runs` | `GET /v1/runs` | Return `{ "runs": [...] }`. |
+| `GET /runs/:runId` | `GET /v1/runs/:runId` | Same run status object. |
+| `POST /attachments` | `POST /v1/attachments` | Same upload behavior. |
+| `GET /runtime/log` | `GET /v1/runtime/log` | Same query parameter. |
+| `POST /runtime/start` | `POST /v1/runtime/start` | Same command result. |
+| `POST /runtime/restart` | `POST /v1/runtime/restart` | Same command result. |
+| `POST /runtime/stop` | `POST /v1/runtime/stop` | Same command result. |
+| `GET /skills` | `GET /v1/skills` | Prefer wrapped list response. |
+| `POST /skills/route` | `POST /v1/skills/route` | Same request initially. |
+| `GET /skills/:id` | `GET /v1/skills/:id` | Same response initially. |
+| `POST /skills/:id/preview` | `POST /v1/skills/:id/preview` | Same response initially. |
+| `POST /skills/:id/run` | `POST /v1/skills/:id/run` | Same response initially. |
+| `GET /skills/:id/runs` | `GET /v1/skills/:id/runs` | Same wrapped list response. |
+| `GET /skill-runs/:runId` | `GET /v1/skill-runs/:runId` | Same response initially. |
+
+Do not require every Android-specific capability to move into the core protocol.
+Nostr/social, terminal, skill sharing, and skill import should remain
+extensions.
+
+## Implementation Order
+
+1. Switch the Termux/OpenClaw companion server public routes to `/v1`.
+2. Add `GET /v1/capabilities` with feature statuses, tool schemas, and
+   extension route discovery.
+3. Upgrade `POST /v1/runs` to support `clientRunId`, `instruction`,
+   `displayText`, `source`, and existing text fallbacks.
+4. Update Android `HttpRuntimeClient` to call `/v1` for core operations.
+5. Update iOS share/task flows to send structured `RunCreateRequest`.
+6. Add the common error model and request id propagation.
+7. Add pairing-token auth for non-local runtime endpoints.
+8. Add approval read/resolve routes for high-risk tools and extension routes.
+9. Add WebSocket events only after HTTP polling is stable across Android and iOS.

--- a/installer/termux-lite/README.md
+++ b/installer/termux-lite/README.md
@@ -154,62 +154,72 @@ by default, and CORS headers are only emitted when
 `CLAWMOBILE_COMPANION_CORS_ORIGIN` is explicitly configured for local
 development.
 
-Current MVP endpoints:
+Current MVP endpoints use the shared ClawMobile runtime protocol v1:
 
 ```text
-GET  /health
-POST /attachments
-POST /intent
-POST /runtime/start
-POST /runtime/stop
-GET  /runtime/log
-POST /terminal/command
-GET  /terminal/session
-POST /terminal/session/input
-POST /terminal/session/reset
-GET  /skills
-POST /skills/route
-GET  /skills/:skillId
-POST /skills/:skillId/preview
-POST /skills/:skillId/run
-POST /skills/:skillId/fast-paths/:fastPathId/run
-GET  /skills/:skillId/runs
-GET  /skill-runs/:runId
-GET  /nostr/status
-POST /nostr/setup-key
-GET  /nostr/contacts
-POST /nostr/contacts
-DELETE /nostr/contacts/:contactId
-POST /nostr/send
-GET  /nostr/inbox
-GET  /agent/conversations
-GET  /agent/conversations/:agentId/messages
-POST /agent/conversations/:agentId/messages
-DELETE /agent/conversations/:agentId/messages
-POST /agent/inbox/fetch
-POST /agent/messages/:messageId/read
-POST /skills/:skillId/share
-POST /skills/:skillId/share/nostr
-GET  /skill-imports
-POST /skill-imports
-POST /skill-imports/:importId/accept
-POST /skill-imports/:importId/reject
-GET  /runs
+GET  /v1/health
+GET  /v1/capabilities
+POST /v1/attachments
+GET  /v1/attachments/:attachmentId/content
+POST /v1/runs
+GET  /v1/runs
+GET  /v1/runs/:runId
+POST /v1/runtime/start
+POST /v1/runtime/stop
+POST /v1/runtime/restart
+GET  /v1/runtime/log
+GET  /v1/skills
+POST /v1/skills/route
+GET  /v1/skills/:skillId
+POST /v1/skills/:skillId/preview
+POST /v1/skills/:skillId/run
+POST /v1/skills/:skillId/fast-paths/:fastPathId/run
+GET  /v1/skills/:skillId/runs
+GET  /v1/skill-runs/:runId
+POST /v1/sessions/:sessionId/archive
+DELETE /v1/sessions/:sessionId
+
+POST /v1/extensions/android/terminal/command
+GET  /v1/extensions/android/terminal/session
+POST /v1/extensions/android/terminal/session/input
+POST /v1/extensions/android/terminal/session/reset
+GET  /v1/extensions/nostr/status
+POST /v1/extensions/nostr/setup-key
+GET  /v1/extensions/nostr/contacts
+POST /v1/extensions/nostr/contacts
+DELETE /v1/extensions/nostr/contacts/:contactId
+POST /v1/extensions/nostr/send
+GET  /v1/extensions/nostr/inbox
+GET  /v1/extensions/agent/conversations
+GET  /v1/extensions/agent/conversations/:agentId/messages
+POST /v1/extensions/agent/conversations/:agentId/messages
+DELETE /v1/extensions/agent/conversations/:agentId/messages
+POST /v1/extensions/agent/inbox/fetch
+POST /v1/extensions/agent/messages/:messageId/read
+POST /v1/extensions/skill-sharing/skills/:skillId/share
+POST /v1/extensions/skill-sharing/skills/:skillId/share/nostr
+GET  /v1/extensions/skill-sharing/imports
+POST /v1/extensions/skill-sharing/imports
+POST /v1/extensions/skill-sharing/imports/:importId/accept
+POST /v1/extensions/skill-sharing/imports/:importId/reject
 ```
 
-`/health` returns ClawMobile capability health plus OpenClaw gateway reachability.
-`/runtime/start` starts the existing Termux gateway through `run.sh` if it is not
-already reachable. `/runtime/log` returns the current gateway log tail for the
-Android cockpit terminal. Terminal endpoints execute commands inside Termux.
+`/v1/health` returns ClawMobile capability health plus OpenClaw gateway
+reachability. `/v1/capabilities` reports feature availability, tool summaries,
+and extension routes. `/v1/runtime/start` starts the existing Termux gateway
+through `run.sh` if it is not already reachable. `/v1/runtime/log` returns the
+current gateway log tail for the Android cockpit terminal. Terminal extension
+endpoints execute commands inside Termux.
 Companion control endpoints are restricted to loopback requests by default.
-`/intent` accepts a user task,
-returns a run id and session id, and lets the Android app poll `/runs/:runId`
-and `/runs?limit=100` for chat history, progress, tool activity, final result,
-and optional token usage.
+`/v1/runs` accepts a task request with `instruction`, optional `displayText`,
+session id, and attachments, returns a run id and session id, and lets mobile
+apps poll `/v1/runs/:runId` and `/v1/runs?limit=100` for chat history, progress,
+tool activity, final result, and optional token usage.
 
-`/attachments` accepts raw `image/*` uploads from the Android share sheet and
-saves them under `${CLAWMOBILE_ATTACHMENT_DIR:-$HOME/.clawmobile/companion-attachments}`.
-The Android app includes the returned attachment objects in `/intent.attachments`.
+`/v1/attachments` accepts raw `image/*` uploads from the Android share sheet and
+saves them under
+`${CLAWMOBILE_ATTACHMENT_DIR:-$HOME/.clawmobile/companion-attachments}`.
+The app includes the returned attachment objects in `/v1/runs.attachments`.
 The server appends local image paths to the internal OpenClaw prompt while
 preserving the original user-visible request as `userText`.
 
@@ -225,7 +235,7 @@ generated, and later only when the caller explicitly requests a reveal.
 
 ### Skills Library API Contract
 
-The Android app treats `/skills` as a unified Skills Library, not as a generated
+The app treats `/v1/skills` as a unified Skills Library, not as a generated
 skill-only list. The server should return ordinary installed OpenClaw skills,
 generated skills, imported skills, and future user-created skills through the
 same shape. Generated skills can add richer app/scenario knowledge and fast
@@ -233,7 +243,7 @@ paths, but ordinary skills must remain valid without those fields. A generated
 skill should be presented as reusable app/task knowledge first; fast paths are
 optional execution routes.
 
-`GET /skills` returns compact cards:
+`GET /v1/skills` returns compact cards:
 
 - `id`, `name`, `description`
 - `source`: `installed`, `generated`, `demo`, or `unknown`
@@ -249,7 +259,7 @@ optional execution routes.
 - `requiresConfirmation`
 - `tags`
 
-`GET /skills/:skillId` returns the full detail used by the Android skill page:
+`GET /v1/skills/:skillId` returns the full detail used by the Android skill page:
 
 - `overview`
   - `primaryUse`
@@ -284,7 +294,7 @@ derives this shape from markdown, frontmatter, `generalized_skill.json`,
 
 ### Local Skill Routing
 
-`POST /skills/route` performs local metadata routing without a model call:
+`POST /v1/skills/route` performs local metadata routing without a model call:
 
 ```json
 {
@@ -304,11 +314,11 @@ includes `confidence`, `reasons`, `recommendedRoute`, `secondaryRoutes`,
 `missingInputs`, and an `autoRun` decision. The route step itself has
 `tokenCost: "none_local_metadata_match"`.
 
-`POST /intent` also uses the same local router conservatively. When exactly one
-high-confidence skill match exists, the runtime appends a compact skill context
-to the submitted prompt. When no high-confidence match exists, the submitted
-prompt is unchanged. Set `CLAWMOBILE_AUTO_SKILL_ROUTING=0` to disable this
-automatic context attachment.
+`POST /v1/runs` also uses the same local router conservatively. When exactly
+one high-confidence skill match exists, the runtime appends a compact skill
+context to the submitted instruction. When no high-confidence match exists, the
+submitted instruction is unchanged. Set `CLAWMOBILE_AUTO_SKILL_ROUTING=0` to
+disable this automatic context attachment.
 
 Automatic fast-path execution is not enabled by default. A caller must set
 `allowAutoFastPath: true`, and the route must be high-confidence, have required
@@ -316,7 +326,7 @@ inputs available, avoid high-risk actions, and have no blocking failure history.
 
 ### Skills Execution API
 
-`POST /skills/:skillId/preview` accepts:
+`POST /v1/skills/:skillId/preview` accepts:
 
 ```json
 {
@@ -348,15 +358,16 @@ exists.
 - `agent_guidance`: ordinary installed skill guidance.
 - `broken`: the generated skill metadata could not be loaded.
 
-`POST /skills/:skillId/run` creates a normal OpenClaw agent run with the skill
+`POST /v1/skills/:skillId/run` creates a normal OpenClaw agent run with the skill
 loaded as compact context. It accepts `instruction`, `taskText`, `text`,
 `inputs`, and optional `sessionId`. This route does not force replay. Use it
 as the default route when the UI wants the agent to reuse app knowledge,
 grounding hints, verification rules, prior execution evidence, and available
 tools.
 
-`POST /skills/:skillId/fast-paths/:fastPathId/run` calls the generated skill
-fast-path runner. It accepts:
+`POST /v1/skills/:skillId/fast-paths/:fastPathId/run` calls the generated skill
+fast-path runner. This remains an Android generated-skill extension on top of
+the core v1 skills API. It accepts:
 
 ```json
 {
@@ -382,19 +393,19 @@ includes `success`, `state`, Android-facing `status`, `message`,
 - The Android frontend already has a Skill Library MVP in `SkillModels.kt`,
   `HttpRuntimeClient.kt`, and `SkillsScreen.kt`; the next step is sync,
   verification, and incremental fixes, not a rewrite.
-- Keep the existing list/detail/preview/run/fast-path/run-history calls. The
-  companion server also supports `/skills/:skillId/runs` and
-  `/skill-runs/:runId` for the Android skill history UI.
+- Keep the existing list/detail/preview/run/fast-path/run-history concepts, but
+  call them through `/v1`. The companion server also supports
+  `/v1/skills/:skillId/runs` and `/v1/skill-runs/:runId` for skill history UI.
 - The Android frontend consumes optional fields for the knowledge-first model:
   `appPackage`, `routeCount`, `appModel`, `knowledgeShortcuts`,
   `executionRoutes`, `executionState`, `recommendedAction`, `missingInputs`,
   and `eligibleFastPaths`.
-- Keep `POST /skills/route` available for local skill suggestions before a
+- Keep `POST /v1/skills/route` available for local skill suggestions before a
   free-form intent is submitted.
 - Preserve the original user task as `userText`, `inputText`, or `intentText`
-  when `/intent` injects compact skill context. The Android chat UI uses this
+  when `/v1/runs` injects compact skill context. The mobile chat UI uses this
   field instead of the expanded OpenClaw prompt.
-- Preserve the original user task as `userText` when `/intent` injects local
+- Preserve the original user task as `userText` when `/v1/runs` injects local
   attachment paths for shared images.
 - Update run `updatedAt` when a terminal `done` or `failed` result arrives so
   the Android unread badges and recent chats can refresh correctly.

--- a/openclaw-plugin-mobile-ui/src/companion/intent.ts
+++ b/openclaw-plugin-mobile-ui/src/companion/intent.ts
@@ -11,13 +11,16 @@ export async function submitIntent(
   text: string,
   sessionId = "default",
   attachments: IntentAttachment[] = [],
+  options: { userText?: string; clientRunId?: string } = {},
 ): Promise<IntentSubmitResponse> {
   const normalized = text.trim();
+  const visibleUserText = (options.userText || normalized).trim();
   const normalizedSessionId = normalizeCompanionSessionId(sessionId);
   if (!normalized) {
     return {
       success: false,
       runId: "",
+      clientRunId: options.clientRunId,
       sessionId: normalizedSessionId,
       result: "",
       message: "Intent text is required.",
@@ -31,10 +34,11 @@ export async function submitIntent(
     return {
       success: false,
       runId,
+      clientRunId: options.clientRunId,
       sessionId: normalizedSessionId,
       result: gateway.message,
       message: gateway.message,
-      canvas: intentCanvas(normalized, gateway.message),
+      canvas: intentCanvas(visibleUserText, gateway.message),
       attachments,
     };
   }
@@ -43,19 +47,20 @@ export async function submitIntent(
   const promptWithAttachments = appendAttachmentContext(normalized, attachments);
   const routed = buildAutoSkillContextForIntent(promptWithAttachments);
   const submittedPrompt = routed?.prompt || promptWithAttachments;
-  await rememberSubmittedRun(submittedPrompt, accepted, { userText: normalized, attachments });
-  void submitIntentInBackground(submittedPrompt, runId, normalizedSessionId, normalized, attachments);
+  await rememberSubmittedRun(submittedPrompt, accepted, { userText: visibleUserText, attachments });
+  void submitIntentInBackground(submittedPrompt, runId, normalizedSessionId, visibleUserText, attachments);
 
   const message = describeOpenClawResult(accepted);
   return {
     success: true,
     runId,
+    clientRunId: options.clientRunId,
     sessionId: normalizedSessionId,
     state: "running",
     result: message,
     message,
-    userText: normalized,
-    canvas: intentCanvas(normalized, message),
+    userText: visibleUserText,
+    canvas: intentCanvas(visibleUserText, message),
     attachments,
     gatewayRun: includeRawIntent() ? { ...accepted, skillRouting: routed?.routed } : undefined,
   };
@@ -85,7 +90,7 @@ async function submitIntentInBackground(
 
 function appendAttachmentContext(text: string, attachments: IntentAttachment[]) {
   const imageAttachments = attachments.filter((attachment) =>
-    String(attachment.type || "").toLowerCase() === "image" && attachment.path,
+    String(attachment.type || "").toLowerCase() === "image" && (attachment.path || attachment.serverPath),
   );
   if (imageAttachments.length === 0) return text;
 
@@ -93,7 +98,7 @@ function appendAttachmentContext(text: string, attachments: IntentAttachment[]) 
     const label = attachment.displayName || attachment.id || `image-${index + 1}`;
     const mime = attachment.mimeType ? `, ${attachment.mimeType}` : "";
     const size = attachment.sizeBytes ? `, ${attachment.sizeBytes} bytes` : "";
-    return `- ${label}${mime}${size}: ${attachment.path}`;
+    return `- ${label}${mime}${size}: ${attachment.path || attachment.serverPath}`;
   });
 
   return [

--- a/openclaw-plugin-mobile-ui/src/companion/nostr.ts
+++ b/openclaw-plugin-mobile-ui/src/companion/nostr.ts
@@ -362,7 +362,7 @@ function requireIdentity() {
   const config = readConfig();
   const secretKey = hexToBytes(config.secretKeyHex || "");
   if (!secretKey) {
-    throw new Error("Nostr identity is not configured. Call POST /nostr/setup-key first.");
+    throw new Error("Nostr identity is not configured. Call POST /v1/extensions/nostr/setup-key first.");
   }
   const publicKey = getPublicKey(secretKey);
   return { config, secretKey, publicKey };

--- a/openclaw-plugin-mobile-ui/src/companion/server.ts
+++ b/openclaw-plugin-mobile-ui/src/companion/server.ts
@@ -106,7 +106,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (isLocalOnlyRoute(routePath) && !isLoopbackRequest(req) && process.env.CLAWMOBILE_COMPANION_ALLOW_REMOTE_TERMINAL !== "1") {
+  if (isLocalOnlyRoute(routePath, method) && !isLoopbackRequest(req)) {
     writeJson(res, 403, {
       success: false,
       message: "This endpoint is restricted to local companion app requests.",
@@ -682,16 +682,6 @@ async function capabilities() {
         extension: "android",
         permissions: [],
       },
-      {
-        id: "terminal.command",
-        label: "Run Terminal Command",
-        description: "Run a shell command in the companion runtime.",
-        status: "available",
-        risk: "high",
-        requiresApproval: true,
-        extension: "android",
-        permissions: ["local_loopback"],
-      },
     ],
     extensions: [
       {
@@ -699,8 +689,8 @@ async function capabilities() {
         basePath: "/v1/extensions/android",
         status: "available",
         routes: [
-          { id: "terminal.command", method: "POST", path: "/terminal/command", status: "available", risk: "high", requiresApproval: true },
-          { id: "terminal.session", method: "GET", path: "/terminal/session", status: "available", risk: "medium", requiresApproval: false },
+          { id: "terminal.command", method: "POST", path: "terminal/command", status: "local_only", risk: "high", requiresApproval: false, availabilityReason: "Loopback-only companion UI route; not an agent-callable tool." },
+          { id: "terminal.session", method: "GET", path: "terminal/session", status: "local_only", risk: "medium", requiresApproval: false },
         ],
       },
       {
@@ -708,9 +698,9 @@ async function capabilities() {
         basePath: "/v1/extensions/nostr",
         status: "available",
         routes: [
-          { id: "nostr.status", method: "GET", path: "/status", status: "available", risk: "low", requiresApproval: false },
-          { id: "nostr.contacts", method: "GET", path: "/contacts", status: "available", risk: "low", requiresApproval: false },
-          { id: "nostr.send", method: "POST", path: "/send", status: "available", risk: "medium", requiresApproval: false },
+          { id: "nostr.status", method: "GET", path: "status", status: "available", risk: "low", requiresApproval: false },
+          { id: "nostr.contacts", method: "GET", path: "contacts", status: "available", risk: "low", requiresApproval: false },
+          { id: "nostr.send", method: "POST", path: "send", status: "available", risk: "medium", requiresApproval: false },
         ],
       },
       {
@@ -718,7 +708,7 @@ async function capabilities() {
         basePath: "/v1/extensions/agent",
         status: "available",
         routes: [
-          { id: "agent.conversations", method: "GET", path: "/conversations", status: "available", risk: "low", requiresApproval: false },
+          { id: "agent.conversations", method: "GET", path: "conversations", status: "available", risk: "low", requiresApproval: false },
         ],
       },
       {
@@ -726,8 +716,8 @@ async function capabilities() {
         basePath: "/v1/extensions/skill-sharing",
         status: "available",
         routes: [
-          { id: "skill-sharing.imports", method: "GET", path: "/imports", status: "available", risk: "low", requiresApproval: false },
-          { id: "skill-sharing.share", method: "POST", path: "/skills/:skillId/share", status: "available", risk: "medium", requiresApproval: false },
+          { id: "skill-sharing.imports", method: "GET", path: "imports", status: "available", risk: "low", requiresApproval: false },
+          { id: "skill-sharing.share", method: "POST", path: "skills/:skillId/share", status: "available", risk: "medium", requiresApproval: false },
         ],
       },
     ],
@@ -1121,15 +1111,11 @@ function isTerminalRoute(pathname: string) {
     pathname === "/terminal/session/reset";
 }
 
-function isLocalOnlyRoute(pathname: string) {
-  return isTerminalRoute(pathname) ||
-    pathname === "/attachments" ||
-    pathname.startsWith("/attachments/") ||
-    pathname.startsWith("/agent/") ||
-    pathname.startsWith("/nostr/") ||
-    pathname === "/skill-imports" ||
-    pathname.startsWith("/skill-imports/") ||
-    /^\/skills\/[^/]+\/share(?:\/nostr)?$/.test(pathname);
+function isLocalOnlyRoute(pathname: string, method = "GET") {
+  if (method === "GET" && (pathname === "/" || pathname === "/health" || pathname === "/capabilities")) {
+    return false;
+  }
+  return true;
 }
 
 function isLoopbackRequest(req: http.IncomingMessage) {

--- a/openclaw-plugin-mobile-ui/src/companion/server.ts
+++ b/openclaw-plugin-mobile-ui/src/companion/server.ts
@@ -106,7 +106,8 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (isLocalOnlyRoute(routePath, method) && !isLoopbackRequest(req)) {
+  const isLoopback = isLoopbackRequest(req);
+  if (isLocalOnlyRoute(routePath, method) && !isLoopback) {
     writeJson(res, 403, {
       success: false,
       message: "This endpoint is restricted to local companion app requests.",
@@ -170,7 +171,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
   }
 
   if (method === "GET" && routePath === "/capabilities") {
-    writeJson(res, 200, await capabilities());
+    writeJson(res, 200, await capabilities({ trusted: isLoopback }));
     return;
   }
 
@@ -640,7 +641,11 @@ async function health(): Promise<CompanionHealth> {
   };
 }
 
-async function capabilities() {
+async function capabilities(options: { trusted?: boolean } = {}) {
+  if (!options.trusted) {
+    return bootstrapCapabilities();
+  }
+
   const currentHealth = await health();
   const runtime = currentHealth.runtime || {};
   const rawCapabilities = runtime.capabilities || {};
@@ -721,6 +726,22 @@ async function capabilities() {
         ],
       },
     ],
+  };
+}
+
+function bootstrapCapabilities() {
+  return {
+    platform: "android",
+    runtime: "termux-openclaw",
+    version: VERSION,
+    protocol: "v1",
+    access: {
+      status: "auth_required",
+      message: "Pairing or loopback access is required for runtime capabilities.",
+    },
+    features: {},
+    tools: [],
+    extensions: [],
   };
 }
 

--- a/openclaw-plugin-mobile-ui/src/companion/server.ts
+++ b/openclaw-plugin-mobile-ui/src/companion/server.ts
@@ -166,7 +166,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
   }
 
   if (method === "GET" && routePath === "/health") {
-    writeJson(res, 200, await health());
+    writeJson(res, 200, await health({ trusted: isLoopback }));
     return;
   }
 
@@ -590,7 +590,11 @@ function normalizeProtocolPath(pathname: string): string | null {
   return path;
 }
 
-async function health(): Promise<CompanionHealth> {
+async function health(options: { trusted?: boolean } = { trusted: true }): Promise<CompanionHealth> {
+  if (options.trusted === false) {
+    return bootstrapHealth();
+  }
+
   const [runtime, gateway] = await Promise.all([
     android_health().catch((error: any) => ({
       ok: false,
@@ -638,6 +642,29 @@ async function health(): Promise<CompanionHealth> {
     gateway,
     runtime,
     model,
+  };
+}
+
+function bootstrapHealth(): CompanionHealth {
+  return {
+    status: "unknown",
+    message: "ClawMobile companion server is reachable. Pairing or loopback access is required for runtime health.",
+    version: VERSION,
+    checks: [
+      {
+        id: "companion",
+        label: "Companion",
+        state: "online",
+        detail: "Companion HTTP server is reachable.",
+      },
+    ],
+    gateway: {
+      host: "",
+      port: 0,
+      reachable: false,
+      message: "Runtime gateway status requires pairing or loopback access.",
+    },
+    runtime: {},
   };
 }
 

--- a/openclaw-plugin-mobile-ui/src/companion/server.ts
+++ b/openclaw-plugin-mobile-ui/src/companion/server.ts
@@ -12,7 +12,7 @@ import { deleteNostrContact, fetchNostrInbox, getNostrStatus, listNostrContacts,
 import { archiveSession, deleteSession, getRunStatus, listRuns } from "./runs";
 import { getWorkspaceSkill, listWorkspaceSkills, previewWorkspaceSkill, routeWorkspaceSkills, runWorkspaceFastPath, runWorkspaceSkill } from "./skills";
 import { acceptSkillImport, createSkillSharePackage, listPendingSkillImports, rejectSkillImport, storePendingSkillImport } from "./skillSharing";
-import type { CompanionHealth, CompanionRunStatus, IntentAttachment, IntentRequest, TerminalCommandRequest, TerminalCommandResponse, TerminalSessionRequest, TerminalSessionResponse } from "./types";
+import type { CompanionHealth, CompanionRunStatus, IntentAttachment, RunCreateRequest, TerminalCommandRequest, TerminalCommandResponse, TerminalSessionRequest, TerminalSessionResponse } from "./types";
 
 const VERSION = "0.1.0";
 const DEFAULT_HOST = "127.0.0.1";
@@ -83,8 +83,9 @@ export function startCompanionServer() {
 async function route(req: http.IncomingMessage, res: http.ServerResponse) {
   const method = req.method || "GET";
   const requestUrl = new URL(req.url || "/", "http://localhost");
+  const routePath = normalizeProtocolPath(requestUrl.pathname);
 
-  if (shouldBlockBrowserRequest(req, requestUrl.pathname)) {
+  if (shouldBlockBrowserRequest(req, routePath || requestUrl.pathname)) {
     writeJson(res, 403, {
       success: false,
       message: "Browser-origin requests are not allowed for local companion control endpoints.",
@@ -97,7 +98,15 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (isLocalOnlyRoute(requestUrl.pathname) && !isLoopbackRequest(req) && process.env.CLAWMOBILE_COMPANION_ALLOW_REMOTE_TERMINAL !== "1") {
+  if (!routePath) {
+    writeJson(res, 404, {
+      success: false,
+      message: `No route for ${method} ${requestUrl.pathname}. Use the /v1 runtime protocol.`,
+    });
+    return;
+  }
+
+  if (isLocalOnlyRoute(routePath) && !isLoopbackRequest(req) && process.env.CLAWMOBILE_COMPANION_ALLOW_REMOTE_TERMINAL !== "1") {
     writeJson(res, 403, {
       success: false,
       message: "This endpoint is restricted to local companion app requests.",
@@ -105,76 +114,138 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/") {
+  if (method === "GET" && routePath === "/") {
     writeJson(res, 200, {
       name: "ClawMobile Companion Server",
       version: VERSION,
-      endpoints: ["/health", "/attachments", "/intent", "/runtime/start", "/runtime/stop", "/runtime/restart", "/runtime/log", "/terminal/command", "/terminal/session", "/terminal/session/input", "/terminal/session/reset", "/skills", "/skills/route", "/skills/:skillId", "/skills/:skillId/share", "/skills/:skillId/share/nostr", "/skills/:skillId/preview", "/skills/:skillId/run", "/skills/:skillId/fast-paths/:fastPathId/run", "/skill-imports", "/skill-imports/:importId/accept", "/skill-imports/:importId/reject", "/nostr/status", "/nostr/setup-key", "/nostr/contacts", "/nostr/contacts/:contactId", "/nostr/send", "/nostr/inbox", "/agent/conversations", "/agent/conversations/:agentId/messages", "/agent/inbox/fetch", "/agent/messages/:messageId/read", "/runs", "/runs/:runId", "/sessions/:sessionId/archive", "/sessions/:sessionId"],
+      protocol: "v1",
+      endpoints: [
+        "/v1/health",
+        "/v1/capabilities",
+        "/v1/attachments",
+        "/v1/attachments/:attachmentId/content",
+        "/v1/runs",
+        "/v1/runs/:runId",
+        "/v1/sessions/:sessionId/archive",
+        "/v1/sessions/:sessionId",
+        "/v1/runtime/start",
+        "/v1/runtime/stop",
+        "/v1/runtime/restart",
+        "/v1/runtime/log",
+        "/v1/skills",
+        "/v1/skills/route",
+        "/v1/skills/:skillId",
+        "/v1/skills/:skillId/preview",
+        "/v1/skills/:skillId/run",
+        "/v1/skills/:skillId/fast-paths/:fastPathId/run",
+        "/v1/skills/:skillId/runs",
+        "/v1/skill-runs/:runId",
+        "/v1/extensions/android/terminal/command",
+        "/v1/extensions/android/terminal/session",
+        "/v1/extensions/android/terminal/session/input",
+        "/v1/extensions/android/terminal/session/reset",
+        "/v1/extensions/nostr/status",
+        "/v1/extensions/nostr/setup-key",
+        "/v1/extensions/nostr/contacts",
+        "/v1/extensions/nostr/contacts/:contactId",
+        "/v1/extensions/nostr/send",
+        "/v1/extensions/nostr/inbox",
+        "/v1/extensions/agent/conversations",
+        "/v1/extensions/agent/conversations/:agentId/messages",
+        "/v1/extensions/agent/inbox/fetch",
+        "/v1/extensions/agent/messages/:messageId/read",
+        "/v1/extensions/skill-sharing/skills/:skillId/share",
+        "/v1/extensions/skill-sharing/skills/:skillId/share/nostr",
+        "/v1/extensions/skill-sharing/imports",
+        "/v1/extensions/skill-sharing/imports/:importId/accept",
+        "/v1/extensions/skill-sharing/imports/:importId/reject",
+      ],
     });
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/health") {
+  if (method === "GET" && routePath === "/health") {
     writeJson(res, 200, await health());
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/intent") {
-    const body = await readJsonBody<IntentRequest>(req);
-    const result = await submitIntent(String(body?.text || ""), String(body?.sessionId || "default"), body?.attachments || []);
+  if (method === "GET" && routePath === "/capabilities") {
+    writeJson(res, 200, await capabilities());
+    return;
+  }
+
+  if (method === "POST" && routePath === "/runs") {
+    const body = await readJsonBody<RunCreateRequest>(req);
+    const instruction = String(body?.instruction || body?.text || "");
+    const displayText = String(body?.displayText || body?.userText || body?.text || instruction);
+    const result = await submitIntent(
+      instruction,
+      String(body?.sessionId || "default"),
+      body?.attachments || [],
+      {
+        userText: displayText,
+        clientRunId: body?.clientRunId,
+      },
+    );
     writeJson(res, result.success ? 200 : 400, result);
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/attachments") {
+  if (method === "POST" && routePath === "/attachments") {
     const result = await saveAttachment(req);
     writeJson(res, result.success ? 200 : 400, result);
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/runtime/start") {
+  if (method === "GET" && routePath.startsWith("/attachments/") && routePath.endsWith("/content")) {
+    const attachmentId = decodeURIComponent(routePath.slice("/attachments/".length, -"/content".length));
+    await serveAttachmentContent(res, attachmentId);
+    return;
+  }
+
+  if (method === "POST" && routePath === "/runtime/start") {
     writeJson(res, 200, await startRuntime());
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/runtime/stop") {
+  if (method === "POST" && routePath === "/runtime/stop") {
     const result = await stopRuntime();
     writeJson(res, result.success ? 200 : 500, result);
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/runtime/restart") {
+  if (method === "POST" && routePath === "/runtime/restart") {
     const result = await restartRuntime();
     writeJson(res, result.success ? 200 : 500, result);
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/runtime/log") {
+  if (method === "GET" && routePath === "/runtime/log") {
     const maxBytes = parsePort(requestUrl.searchParams.get("maxBytes") || undefined, 64 * 1024);
     writeJson(res, 200, getRuntimeLog(maxBytes));
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/terminal/command") {
+  if (method === "POST" && routePath === "/terminal/command") {
     const body = await readJsonBody<TerminalCommandRequest>(req);
     const result = await runTerminalCommand(String(body?.command || ""));
     writeJson(res, result.command ? 200 : 400, result);
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/terminal/session") {
+  if (method === "GET" && routePath === "/terminal/session") {
     writeJson(res, 200, terminalSessionSnapshot("Shell ready."));
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/terminal/session/input") {
+  if (method === "POST" && routePath === "/terminal/session/input") {
     const body = await readJsonBody<TerminalSessionRequest>(req);
     const result = sendTerminalSessionInput(String(body?.text || ""));
     writeJson(res, result.success ? 200 : 400, result);
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/terminal/session/reset") {
+  if (method === "POST" && routePath === "/terminal/session/reset") {
     stopTerminalShellSession();
     const session = startTerminalShellSession();
     appendTerminalShellText(session, "Shell restarted.\n");
@@ -182,25 +253,25 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/skills") {
+  if (method === "GET" && routePath === "/skills") {
     writeJson(res, 200, {
       skills: listWorkspaceSkills(),
     });
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/skills/route") {
+  if (method === "POST" && routePath === "/skills/route") {
     const body = await readJsonBody<Record<string, any>>(req);
     writeJson(res, 200, routeWorkspaceSkills(body || {}));
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/nostr/status") {
+  if (method === "GET" && routePath === "/nostr/status") {
     writeJson(res, 200, getNostrStatus());
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/nostr/setup-key") {
+  if (method === "POST" && routePath === "/nostr/setup-key") {
     const body = await readJsonBody<Record<string, any>>(req);
     writeJson(res, 200, setupNostrIdentity({
       secretKey: body?.secretKey || body?.nsec,
@@ -210,18 +281,18 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/nostr/contacts") {
+  if (method === "GET" && routePath === "/nostr/contacts") {
     writeJson(res, 200, listNostrContacts());
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/nostr/contacts") {
+  if (method === "POST" && routePath === "/nostr/contacts") {
     const body = await readJsonBody<Record<string, any>>(req);
     writeJson(res, 200, upsertNostrContact(body || {}));
     return;
   }
 
-  const nostrContactMatch = requestUrl.pathname.match(/^\/nostr\/contacts\/([^/]+)$/);
+  const nostrContactMatch = routePath.match(/^\/nostr\/contacts\/([^/]+)$/);
   if (method === "DELETE" && nostrContactMatch) {
     const contactId = decodeURIComponent(nostrContactMatch[1]);
     const result = deleteNostrContact({ value: contactId });
@@ -229,14 +300,14 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/nostr/send") {
+  if (method === "POST" && routePath === "/nostr/send") {
     const body = await readJsonBody<Record<string, any>>(req);
     const result = await sendNostrAgentMessage(body || {});
     writeJson(res, result.ok ? 200 : 502, result);
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/nostr/inbox") {
+  if (method === "GET" && routePath === "/nostr/inbox") {
     const limit = Number.parseInt(requestUrl.searchParams.get("limit") || "", 10);
     const since = Number.parseInt(requestUrl.searchParams.get("since") || "", 10);
     const relays = requestUrl.searchParams.getAll("relay").filter(Boolean);
@@ -249,7 +320,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/agent/conversations") {
+  if (method === "GET" && routePath === "/agent/conversations") {
     writeJson(res, 200, {
       ok: true,
       conversations: listAgentConversations(listNostrContacts().contacts),
@@ -257,7 +328,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const agentMessagesMatch = requestUrl.pathname.match(/^\/agent\/conversations\/([^/]+)\/messages$/);
+  const agentMessagesMatch = routePath.match(/^\/agent\/conversations\/([^/]+)\/messages$/);
   if (method === "GET" && agentMessagesMatch) {
     const agentId = decodeURIComponent(agentMessagesMatch[1]);
     const limit = Number.parseInt(requestUrl.searchParams.get("limit") || "", 10);
@@ -300,7 +371,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/agent/inbox/fetch") {
+  if (method === "POST" && routePath === "/agent/inbox/fetch") {
     const body: Record<string, any> = await readJsonBody<Record<string, any>>(req).catch(() => ({}));
     const result = await fetchNostrInbox({
       limit: Number.isFinite(Number(body?.limit)) ? Number(body.limit) : 50,
@@ -320,7 +391,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const markAgentMessageReadMatch = requestUrl.pathname.match(/^\/agent\/messages\/([^/]+)\/read$/);
+  const markAgentMessageReadMatch = routePath.match(/^\/agent\/messages\/([^/]+)\/read$/);
   if (method === "POST" && markAgentMessageReadMatch) {
     const messageId = decodeURIComponent(markAgentMessageReadMatch[1]);
     const body: Record<string, any> = await readJsonBody<Record<string, any>>(req).catch(() => ({}));
@@ -329,14 +400,14 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/skill-imports") {
+  if (method === "GET" && routePath === "/skill-imports") {
     writeJson(res, 200, {
       imports: listPendingSkillImports(),
     });
     return;
   }
 
-  if (method === "POST" && requestUrl.pathname === "/skill-imports") {
+  if (method === "POST" && routePath === "/skill-imports") {
     const body = await readJsonBody<Record<string, any>>(req);
     const record = storePendingSkillImport(body?.package || body, body?.source || { transport: "manual" });
     writeJson(res, 200, {
@@ -347,7 +418,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const acceptSkillImportMatch = requestUrl.pathname.match(/^\/skill-imports\/([^/]+)\/accept$/);
+  const acceptSkillImportMatch = routePath.match(/^\/skill-imports\/([^/]+)\/accept$/);
   if (method === "POST" && acceptSkillImportMatch) {
     const importId = decodeURIComponent(acceptSkillImportMatch[1]);
     const result = acceptSkillImport(importId);
@@ -358,7 +429,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const rejectSkillImportMatch = requestUrl.pathname.match(/^\/skill-imports\/([^/]+)\/reject$/);
+  const rejectSkillImportMatch = routePath.match(/^\/skill-imports\/([^/]+)\/reject$/);
   if (method === "POST" && rejectSkillImportMatch) {
     const importId = decodeURIComponent(rejectSkillImportMatch[1]);
     const result = rejectSkillImport(importId);
@@ -369,7 +440,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const skillDetailMatch = requestUrl.pathname.match(/^\/skills\/([^/]+)$/);
+  const skillDetailMatch = routePath.match(/^\/skills\/([^/]+)$/);
   if (method === "GET" && skillDetailMatch) {
     const skillId = decodeURIComponent(skillDetailMatch[1]);
     const skill = getWorkspaceSkill(skillId);
@@ -380,7 +451,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const skillShareMatch = requestUrl.pathname.match(/^\/skills\/([^/]+)\/share$/);
+  const skillShareMatch = routePath.match(/^\/skills\/([^/]+)\/share$/);
   if (method === "POST" && skillShareMatch) {
     const skillId = decodeURIComponent(skillShareMatch[1]);
     const result = createSkillSharePackage(skillId);
@@ -391,7 +462,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const skillShareNostrMatch = requestUrl.pathname.match(/^\/skills\/([^/]+)\/share\/nostr$/);
+  const skillShareNostrMatch = routePath.match(/^\/skills\/([^/]+)\/share\/nostr$/);
   if (method === "POST" && skillShareNostrMatch) {
     const skillId = decodeURIComponent(skillShareNostrMatch[1]);
     const body = await readJsonBody<Record<string, any>>(req);
@@ -403,7 +474,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const skillPreviewMatch = requestUrl.pathname.match(/^\/skills\/([^/]+)\/preview$/);
+  const skillPreviewMatch = routePath.match(/^\/skills\/([^/]+)\/preview$/);
   if (method === "POST" && skillPreviewMatch) {
     const skillId = decodeURIComponent(skillPreviewMatch[1]);
     const body = await readJsonBody<Record<string, any>>(req);
@@ -415,7 +486,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const skillRunMatch = requestUrl.pathname.match(/^\/skills\/([^/]+)\/run$/);
+  const skillRunMatch = routePath.match(/^\/skills\/([^/]+)\/run$/);
   if (method === "POST" && skillRunMatch) {
     const skillId = decodeURIComponent(skillRunMatch[1]);
     const body = await readJsonBody<Record<string, any>>(req);
@@ -427,7 +498,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const fastPathRunMatch = requestUrl.pathname.match(/^\/skills\/([^/]+)\/fast-paths\/([^/]+)\/run$/);
+  const fastPathRunMatch = routePath.match(/^\/skills\/([^/]+)\/fast-paths\/([^/]+)\/run$/);
   if (method === "POST" && fastPathRunMatch) {
     const skillId = decodeURIComponent(fastPathRunMatch[1]);
     const fastPathId = decodeURIComponent(fastPathRunMatch[2]);
@@ -440,7 +511,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const skillRunsMatch = requestUrl.pathname.match(/^\/skills\/([^/]+)\/runs$/);
+  const skillRunsMatch = routePath.match(/^\/skills\/([^/]+)\/runs$/);
   if (method === "GET" && skillRunsMatch) {
     const skillId = decodeURIComponent(skillRunsMatch[1]);
     const runs = (await listRuns())
@@ -450,14 +521,14 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname.startsWith("/skill-runs/")) {
-    const runId = decodeURIComponent(requestUrl.pathname.slice("/skill-runs/".length));
+  if (method === "GET" && routePath.startsWith("/skill-runs/")) {
+    const runId = decodeURIComponent(routePath.slice("/skill-runs/".length));
     const result = await getRunStatus(runId);
     writeJson(res, result.success || result.state !== "unknown" ? 200 : 404, toSkillRunSummary(result));
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname === "/runs") {
+  if (method === "GET" && routePath === "/runs") {
     const rawLimit = Number.parseInt(requestUrl.searchParams.get("limit") || "", 10);
     const limit = Number.isFinite(rawLimit) ? rawLimit : undefined;
     writeJson(res, 200, {
@@ -466,14 +537,14 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  if (method === "GET" && requestUrl.pathname.startsWith("/runs/")) {
-    const runId = decodeURIComponent(requestUrl.pathname.slice("/runs/".length));
+  if (method === "GET" && routePath.startsWith("/runs/")) {
+    const runId = decodeURIComponent(routePath.slice("/runs/".length));
     const result = await getRunStatus(runId);
     writeJson(res, result.success || result.state !== "unknown" ? 200 : 404, result);
     return;
   }
 
-  const archiveSessionMatch = requestUrl.pathname.match(/^\/sessions\/([^/]+)\/archive$/);
+  const archiveSessionMatch = routePath.match(/^\/sessions\/([^/]+)\/archive$/);
   if (method === "POST" && archiveSessionMatch) {
     const sessionId = decodeURIComponent(archiveSessionMatch[1]);
     const result = await archiveSession(sessionId);
@@ -481,7 +552,7 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
     return;
   }
 
-  const deleteSessionMatch = requestUrl.pathname.match(/^\/sessions\/([^/]+)$/);
+  const deleteSessionMatch = routePath.match(/^\/sessions\/([^/]+)$/);
   if (method === "DELETE" && deleteSessionMatch) {
     const sessionId = decodeURIComponent(deleteSessionMatch[1]);
     const result = await deleteSession(sessionId);
@@ -495,6 +566,29 @@ async function route(req: http.IncomingMessage, res: http.ServerResponse) {
   });
 }
 
+function normalizeProtocolPath(pathname: string): string | null {
+  if (pathname === "/" || pathname === "/v1") return "/";
+  if (!pathname.startsWith("/v1/")) return null;
+
+  const path = pathname.slice("/v1".length);
+  const extensionMappings: Array<[string, string]> = [
+    ["/extensions/android", ""],
+    ["/extensions/nostr", "/nostr"],
+    ["/extensions/agent", "/agent"],
+    ["/extensions/skill-sharing/imports", "/skill-imports"],
+    ["/extensions/skill-sharing/skills", "/skills"],
+  ];
+
+  for (const [prefix, replacement] of extensionMappings) {
+    if (path === prefix) return replacement || "/";
+    if (path.startsWith(`${prefix}/`)) {
+      return `${replacement}${path.slice(prefix.length)}` || "/";
+    }
+  }
+
+  return path;
+}
+
 async function health(): Promise<CompanionHealth> {
   const [runtime, gateway] = await Promise.all([
     android_health().catch((error: any) => ({
@@ -505,13 +599,138 @@ async function health(): Promise<CompanionHealth> {
   ]);
 
   const runtimeOk = runtime?.ok !== false;
+  const runtimeDetails: any = runtime;
+  const runtimeStage = typeof runtimeDetails?.stage === "string" ? runtimeDetails.stage : undefined;
+  const runtimeError = runtimeDetails?.error ? String(runtimeDetails.error) : undefined;
+  const model = modelKeyHealth();
   return {
-    status: runtimeOk ? "ok" : "degraded",
+    status: runtimeOk ? "connected" : "disconnected",
     message: runtimeOk ? "ClawMobile companion server is running." : "Companion server is running with degraded runtime health.",
     version: VERSION,
+    stage: runtimeStage,
+    checks: [
+      {
+        id: "companion",
+        label: "Companion",
+        state: "online",
+        detail: "Companion HTTP server is reachable.",
+      },
+      {
+        id: "runtime",
+        label: "Runtime",
+        state: runtimeOk ? "online" : "offline",
+        detail: runtimeOk ? String(runtimeStage || "Runtime capability check passed.") : String(runtimeError || "Runtime capability check failed."),
+      },
+      {
+        id: "gateway",
+        label: "OpenClaw",
+        state: gateway.reachable ? "online" : "offline",
+        detail: gateway.message,
+      },
+      {
+        id: "model",
+        label: "Model",
+        state: model.configured ? "online" : "offline",
+        detail: model.message,
+      },
+    ],
     gateway,
     runtime,
-    model: modelKeyHealth(),
+    model,
+  };
+}
+
+async function capabilities() {
+  const currentHealth = await health();
+  const runtime = currentHealth.runtime || {};
+  const rawCapabilities = runtime.capabilities || {};
+  const modelConfigured = currentHealth.model?.configured === true;
+  const adbReady = rawCapabilities.ui_input === true || rawCapabilities.adb === true;
+  const ocrReady = rawCapabilities.ocr === true || rawCapabilities.screen_ocr === true;
+
+  return {
+    platform: "android",
+    runtime: "termux-openclaw",
+    version: VERSION,
+    health: currentHealth,
+    features: {
+      tasks: "available",
+      sessions: "available",
+      skills: "available",
+      attachments: "available",
+      artifacts: "planned",
+      approvals: "planned",
+      events: "unavailable",
+      runtimeLifecycle: "available",
+      runtimeLog: "available",
+      notifications: "frontend",
+      adb: adbReady ? "available" : "setup_required",
+      ocr: ocrReady ? "available" : "setup_required",
+      terminal: "local_only",
+      social: "available",
+      appIntents: "unavailable",
+      model: modelConfigured ? "available" : "setup_required",
+    },
+    tools: [
+      {
+        id: "android_health",
+        label: "Android Health",
+        description: "Read Android runtime health and setup status.",
+        status: "available",
+        risk: "low",
+        requiresApproval: false,
+        extension: "android",
+        permissions: [],
+      },
+      {
+        id: "terminal.command",
+        label: "Run Terminal Command",
+        description: "Run a shell command in the companion runtime.",
+        status: "available",
+        risk: "high",
+        requiresApproval: true,
+        extension: "android",
+        permissions: ["local_loopback"],
+      },
+    ],
+    extensions: [
+      {
+        namespace: "android",
+        basePath: "/v1/extensions/android",
+        status: "available",
+        routes: [
+          { id: "terminal.command", method: "POST", path: "/terminal/command", status: "available", risk: "high", requiresApproval: true },
+          { id: "terminal.session", method: "GET", path: "/terminal/session", status: "available", risk: "medium", requiresApproval: false },
+        ],
+      },
+      {
+        namespace: "nostr",
+        basePath: "/v1/extensions/nostr",
+        status: "available",
+        routes: [
+          { id: "nostr.status", method: "GET", path: "/status", status: "available", risk: "low", requiresApproval: false },
+          { id: "nostr.contacts", method: "GET", path: "/contacts", status: "available", risk: "low", requiresApproval: false },
+          { id: "nostr.send", method: "POST", path: "/send", status: "available", risk: "medium", requiresApproval: false },
+        ],
+      },
+      {
+        namespace: "agent",
+        basePath: "/v1/extensions/agent",
+        status: "available",
+        routes: [
+          { id: "agent.conversations", method: "GET", path: "/conversations", status: "available", risk: "low", requiresApproval: false },
+        ],
+      },
+      {
+        namespace: "skill-sharing",
+        basePath: "/v1/extensions/skill-sharing",
+        status: "available",
+        routes: [
+          { id: "skill-sharing.imports", method: "GET", path: "/imports", status: "available", risk: "low", requiresApproval: false },
+          { id: "skill-sharing.share", method: "POST", path: "/skills/:skillId/share", status: "available", risk: "medium", requiresApproval: false },
+        ],
+      },
+    ],
   };
 }
 
@@ -551,18 +770,66 @@ async function saveAttachment(req: http.IncomingMessage): Promise<IntentAttachme
     success: true,
     message: "Attachment uploaded.",
     id,
+    serverId: id,
     type: "image",
     mimeType,
     displayName,
     sizeBytes: body.length,
     path: outputPath,
+    serverPath: outputPath,
+    downloadUrl: `/v1/attachments/${encodeURIComponent(id)}/content`,
     createdAt: Date.now(),
   };
+}
+
+async function serveAttachmentContent(res: http.ServerResponse, attachmentId: string) {
+  const id = sanitizeFilePart(attachmentId);
+  if (!id) {
+    writeJson(res, 404, {
+      success: false,
+      message: "Attachment was not found.",
+    });
+    return;
+  }
+
+  const outputDir = attachmentDir();
+  const candidates = ["png", "jpg", "webp", "gif", "img"].map((extension) =>
+    path.join(outputDir, `${id}.${extension}`),
+  );
+  const filePath = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!filePath) {
+    writeJson(res, 404, {
+      success: false,
+      message: "Attachment was not found.",
+    });
+    return;
+  }
+
+  const mimeType = mimeForExtension(path.extname(filePath).replace(/^\./, ""));
+  res.statusCode = 200;
+  res.setHeader("Content-Type", mimeType);
+  fs.createReadStream(filePath).pipe(res);
 }
 
 function attachmentDir() {
   const configured = (process.env.CLAWMOBILE_ATTACHMENT_DIR || "").trim();
   return configured || path.join(os.homedir(), ".clawmobile", "companion-attachments");
+}
+
+function mimeForExtension(extension: string) {
+  switch (extension) {
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "webp":
+      return "image/webp";
+    case "gif":
+      return "image/gif";
+    case "png":
+      return "image/png";
+    default:
+      return "application/octet-stream";
+  }
 }
 
 function sanitizeFilePart(value: string) {
@@ -857,6 +1124,7 @@ function isTerminalRoute(pathname: string) {
 function isLocalOnlyRoute(pathname: string) {
   return isTerminalRoute(pathname) ||
     pathname === "/attachments" ||
+    pathname.startsWith("/attachments/") ||
     pathname.startsWith("/agent/") ||
     pathname.startsWith("/nostr/") ||
     pathname === "/skill-imports" ||
@@ -918,7 +1186,7 @@ function writeJson(res: http.ServerResponse, statusCode: number, value: any) {
   const corsOrigin = (process.env.CLAWMOBILE_COMPANION_CORS_ORIGIN || "").trim();
   if (corsOrigin) {
     res.setHeader("Access-Control-Allow-Origin", corsOrigin);
-    res.setHeader("Access-Control-Allow-Headers", "content-type, authorization, x-clawmobile-attachment-id, x-clawmobile-filename, x-clawmobile-attachment-type");
+    res.setHeader("Access-Control-Allow-Headers", "content-type, authorization, x-clawmobile-client, x-clawmobile-request-id, x-clawmobile-attachment-id, x-clawmobile-filename, x-clawmobile-attachment-type");
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
   }
   res.end(body);

--- a/openclaw-plugin-mobile-ui/src/companion/types.ts
+++ b/openclaw-plugin-mobile-ui/src/companion/types.ts
@@ -14,18 +14,31 @@ export type ModelKeyStatus = {
 };
 
 export type CompanionHealth = {
-  status: "ok" | "degraded";
+  status: "connected" | "disconnected" | "unknown";
   message: string;
   version: string;
+  stage?: string;
+  checks?: Array<{
+    id: string;
+    label: string;
+    state: "online" | "degraded" | "offline" | "unknown";
+    detail?: string;
+  }>;
   gateway: GatewayStatus;
   runtime: any;
   model?: ModelKeyStatus;
 };
 
-export type IntentRequest = {
-  text: string;
+export type RunCreateRequest = {
+  clientRunId?: string;
+  instruction?: string;
+  displayText?: string;
+  text?: string;
+  userText?: string;
   sessionId?: string;
   attachments?: IntentAttachment[];
+  source?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
 };
 
 export type IntentAttachment = {
@@ -36,6 +49,10 @@ export type IntentAttachment = {
   displayName?: string;
   sizeBytes?: number;
   path?: string;
+  serverId?: string;
+  serverPath?: string;
+  downloadUrl?: string;
+  expiresAt?: string | number | null;
   createdAt?: number;
 };
 
@@ -70,6 +87,7 @@ export type TerminalSessionResponse = {
 export type IntentSubmitResponse = {
   success: boolean;
   runId: string;
+  clientRunId?: string;
   sessionId?: string;
   state?: CompanionRunStatus["state"];
   result: string;
@@ -89,6 +107,7 @@ export type CompanionRunStatus = {
   status?: string;
   message: string;
   result?: string;
+  pendingApprovals?: unknown[];
   progress?: CompanionRunProgress;
   prompt?: string;
   userText?: string;


### PR DESCRIPTION
## Summary
- add the shared ClawMobile runtime protocol v1 document
- expose v1 companion server routes for health, runs, runtime lifecycle, skills, Nostr, and skill sharing
- update Termux lite setup docs for the v1 companion runtime flow

## Validation
- npm run build in openclaw-plugin-mobile-ui

This branch was prepared from public/main and cherry-picked from the dev runtime-protocol-v1 branch to avoid bringing dev-only history into the public repo.